### PR TITLE
ci: fix the deploy / check job on PRs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,6 @@ permissions:
 jobs:
   check:
     runs-on: ubuntu-latest
-    environment: check-${{matrix.environment}}
     strategy:
       matrix:
         environment: ["staging", "firefoxci"]
@@ -27,6 +26,13 @@ jobs:
           cache: pip
       - name: Install dependencies
         run: pip install -r requirements/test.txt
+      - name: Set root url
+        run: |
+          if [ "${{ matrix.environment }}" == "staging" ]; then
+            echo "TASKCLUSTER_ROOT_URL=https://stage.taskcluster.nonprod.cloudops.mozgcp.net" >> $GITHUB_ENV;
+          elif [ "${{ matrix.environment }}" == "firefoxci" ]; then
+            echo "TASKCLUSTER_ROOT_URL=https://firefox-ci-tc.services.mozilla.com" >> $GITHUB_ENV;
+          fi
       - name: Run checks
         run: tc-admin check --environment ${{matrix.environment}}
 


### PR DESCRIPTION
It turns out PRs can't access the env defined in the Github environment, so we need to dynamically write the proper value to the $GITHUB_ENV file instead.