### PR TITLE
Bug 1903226 - remove treestatus project and grants.

### DIFF
--- a/clients.yml
+++ b/clients.yml
@@ -1261,30 +1261,6 @@ project/releng/treeherder/production:
   description: Treeherder production client
   scopes:
     - notify:email:*
-project/releng/treestatus/dev:
-  description: ''
-  scopes:
-    - notify:email:*
-    - notify:irc-channel:*
-    - notify:irc-user:*
-project/releng/treestatus/localdev:
-  description: ''
-  scopes:
-    - notify:email:*
-    - notify:irc-channel:*
-    - notify:irc-user:*
-project/releng/treestatus/production:
-  description: ''
-  scopes:
-    - notify:email:*
-    - notify:irc-channel:*
-    - notify:irc-user:*
-project/releng/treestatus/staging:
-  description: ''
-  scopes:
-    - notify:email:*
-    - notify:irc-channel:*
-    - notify:irc-user:*
 project/relman/code-coverage/backend-production:
   description: See [bug 1593751](https://bugzilla.mozilla.org/show_bug.cgi?id=1593751#c20)
   scopes:

--- a/grants.yml
+++ b/grants.yml
@@ -1295,21 +1295,7 @@
         alias: tooltool
         job: [branch:dev, branch:staging, branch:production]
 
-# - treestatus specific roles
-- grant:
-    - secrets:get:project/releng/treestatus/ci
-  to:
-    - projects:
-        alias: treestatus
-        job: [branch:*, pull-request:*]
-
-- grant:
-    - secrets:get:project/releng/treestatus/deploy
-  to:
-    - projects:
-        alias: treestatus
-        job: [branch:dev, branch:staging, branch:production]
-
+# generic github checks
 - grant:
     - queue:route:checks
   to:
@@ -2101,8 +2087,6 @@
     # Allow sheriffs to terminate gecko/mobile related workers
     - worker-manager:remove-worker:gecko-*
     - worker-manager:remove-worker:mobile-*
-    # Allow managing treestatus
-    - project:releng:services/treestatus/*
     # Allow triggering nightlies
     - hooks:trigger-hook:project-releng/cron-task-mozilla-central/nightly-*
     # Allow sheriffs to force schedule a decision task, whenever one has gone
@@ -2185,8 +2169,6 @@
 - grant:
     # Allow triggering thunderbird nightlies
     - hooks:trigger-hook:project-releng/cron-task-comm-central/nightly-*
-    # Allow managing treestatus (This should be limited to comm- trees, see Bug 1613551)
-    - project:releng:services/treestatus/*
     # Bug 1876393: Allow triggering tb-rust-update-check on comm-central
     - hooks:trigger-hook:project-releng/cron-task-comm-central/tb-rust-vendor-check
   to:

--- a/projects.yml
+++ b/projects.yml
@@ -915,25 +915,6 @@ tooltool:
     taskgraph-actions: true
     trust-domain-scopes: true
 
-treestatus:
-  repo: https://github.com/mozilla-releng/treestatus
-  repo_type: git
-  branches:
-    - name: master
-      level: 3
-    - name: production
-      level: 3
-    - name: staging
-      level: 3
-    - name: dev
-      level: 3
-  default_branch: master
-  trust_domain: releng
-  features:
-    github-pull-request:
-      policy: public
-    taskgraph-actions: true
-
 balrog:
   repo: https://github.com/mozilla-releng/balrog
   repo_type: git


### PR DESCRIPTION
The new treestatus doesn't use taskcluster for auth.

Differential Revision: https://phabricator.services.mozilla.com/D216145