### PR TITLE
Bug 1907300: adjust projects.yml branches to match reality

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -396,8 +396,8 @@ try:
   repo_type: hg
   access: scm_level_1
   branches:
+    # Try pushes on branches of any name are supported
     - name: "*"
-    - name: default
   trust_domain: gecko
   is_try: true
   features:
@@ -870,8 +870,6 @@ product-details:
     - name: production
       level: 3
     - name: staging
-      level: 3
-    - name: testing
       level: 3
   features:
     github-pull-request:


### PR DESCRIPTION
Two things were notice since https://bugzilla.mozilla.org/show_bug.cgi?id=1903776 landed:
* There is no testing branch in https://github.com/mozilla-releng/product-details
* https://hg.mozilla.org/try/ can be pushed to on any branch, so we should keep its * branch and drop the explicit reference to default

Already reviewed in https://phabricator.services.mozilla.com/D216274