### PR TITLE
Bug 1907217: remove `*` branch from RelEng github repositories and `maple`

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -450,7 +450,6 @@ maple:
   repo_type: hg
   access: scm_level_3
   branches:
-    - name: "*"
     - name: default
   trust_domain: gecko
   features:
@@ -598,8 +597,6 @@ taskgraph:
   repo_type: git
   trust_domain: taskgraph
   branches:
-    - name: "*"
-      level: 3
     - name: main
       level: 3
   features:
@@ -617,8 +614,6 @@ mozilla-taskgraph:
   trust_domain: taskgraph
   trust_project: mozilla-taskgraph
   branches:
-    - name: "*"
-      level: 3
     - name: main
       level: 3
   features:
@@ -842,8 +837,6 @@ k8s-autoscale:
   repo: https://github.com/mozilla-releng/k8s-autoscale
   repo_type: git
   branches:
-    - name: "*"
-      level: 3
     - name: master
       level: 3
     - name: production
@@ -889,8 +882,6 @@ shipit:
     trust-domain-scopes: true
   trust_domain: releng
   branches:
-    - name: "*"
-      level: 3
     - name: main
       level: 3
     - name: production
@@ -902,8 +893,6 @@ tooltool:
   repo: https://github.com/mozilla-releng/tooltool
   repo_type: git
   branches:
-    - name: "*"
-      level: 3
     - name: master
       level: 3
     - name: production
@@ -926,8 +915,6 @@ treestatus:
   repo: https://github.com/mozilla-releng/treestatus
   repo_type: git
   branches:
-    - name: "*"
-      level: 3
     - name: master
       level: 3
     - name: production
@@ -948,8 +935,6 @@ balrog:
   repo_type: git
   trust_domain: releng
   branches:
-    - name: "*"
-      level: 3
     - name: main
       level: 3
   features:
@@ -963,8 +948,6 @@ scriptworker:
   repo: https://github.com/mozilla-releng/scriptworker
   repo_type: git
   branches:
-    - name: "*"
-      level: 3
     - name: main
       level: 3
   trust_domain: scriptworker
@@ -1150,8 +1133,6 @@ staging-xpi-manifest:
   branches:
     - name: "*"
       level: 1
-    - name: main
-      level: 1
   trust_domain: xpi
   features:
     github-pull-request:
@@ -1170,8 +1151,6 @@ staging-xpi-public:
   branches:
     - name: "*"
       level: 1
-    - name: main
-      level: 1
   trust_domain: xpi
   features:
     github-pull-request:
@@ -1184,8 +1163,6 @@ staging-xpi-private:
   repo_type: git
   branches:
     - name: "*"
-      level: 1
-    - name: master
       level: 1
   default_branch: master
   trust_domain: xpi
@@ -1201,8 +1178,6 @@ staging-adhoc-signing:
   repo_type: git
   branches:
     - name: "*"
-      level: 1
-    - name: master
       level: 1
   default_branch: master
   trust_domain: adhoc
@@ -1252,8 +1227,6 @@ scriptworker-scripts:
   repo: https://github.com/mozilla-releng/scriptworker-scripts
   repo_type: git
   branches:
-    - name: "*"
-      level: 3
     - name: master
       level: 3
     - name: production*

--- a/projects.yml
+++ b/projects.yml
@@ -893,6 +893,8 @@ tooltool:
   repo: https://github.com/mozilla-releng/tooltool
   repo_type: git
   branches:
+    - name: main
+      level: 3
     - name: master
       level: 3
     - name: production


### PR DESCRIPTION
Stage one of the plan written out in the bug.

This _should_ be quite safe. For Maple, all of the scopes that `branch:*` has are already granted by `branch:default`.

For GitHub we have some differences, but as far as I can tell, only where the explicit branches have more scopes than `branch:*` due to grants such as https://github.com/mozilla-releng/fxci-config/blob/944ea85da779ab430e932f9829f1f02bb11ee11c/grants.yml#L1185-L1200.

Original revision/discussion in https://phabricator.services.mozilla.com/D216239

`ci-admin diff` for this is in https://gist.github.com/bhearsum/61df6555dea05bebb9c12b491d6259ce