### PR TITLE
ci: improve the look of notify job's Slack messages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,15 +73,51 @@ jobs:
           SLACK_MESSAGE="*Deploy ${{ github.repository }}* (<${WORKFLOW_URL}|view workflow>)"
 
           if [ "${{ needs.check.result }}" == "success" ]; then
-            SLACK_MESSAGE="${SLACK_MESSAGE}\n:white_check_mark: *check* succeeded"
+            CHECK_EMOJI=":white_check_mark:"
+            CHECK_VERB="succeeded"
           else
-            SLACK_MESSAGE="${SLACK_MESSAGE}\n:x: *check* failed"
+            CHECK_EMOJI=":x:"
+            CHECK_VERB="failed"
           fi
 
           if [ "${{ needs.apply.result }}" == "success" ]; then
-            SLACK_MESSAGE="${SLACK_MESSAGE}\n:white_check_mark: *apply* succeeded"
+            APPLY_EMOJI=":white_check_mark:"
+            APPLY_VERB="succeeded"
           else
-            SLACK_MESSAGE="${SLACK_MESSAGE}\n:x: *apply* failed"
+            APPLY_EMOJI=":x:"
+            APPLY_VERB="failed"
           fi
 
-          curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"${SLACK_MESSAGE}\"}" ${{ secrets.SLACK_WEBHOOK_URL }}
+          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
+          SLACK_MESSAGE=$(cat <<-EOF
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Deploy of <https://github.com/${{ github.repository }}|${{ github.repository }}> from <https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${SHORT_SHA}> is resolved"
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${CHECK_EMOJI} check ${CHECK_VERB}\n${APPLY_EMOJI} apply ${APPLY_VERB}"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+                  }
+                }
+              ]
+            }
+          EOF
+          )
+          curl -X POST -H 'Content-type: application/json' --data "${SLACK_MESSAGE}" ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Some improvements to the Slack message that the notify task runs.

Unfortunately I can't access the webhook url secret anymore (and I'm afraid if I revoke it, I won't be able to re-create it). So I haven't been able to it fully.. but I simulated creating the `SLACK_MESSAGE` variable locally and it looks like it should work.