### PR TITLE
Bug 1884740 - add promote_android scopes to gecko shipitscript

### DIFF
--- a/clients.yml
+++ b/clients.yml
@@ -966,16 +966,19 @@ project/releng/scriptworker/v2/shipit/dev/firefoxci-gecko-1:
     - project:releng:services/shipit_api/dev/schedule_phase/devedition/ship_devedition
     - project:releng:services/shipit_api/dev/schedule_phase/firefox/ship_firefox
     - project:releng:services/shipit_api/dev/schedule_phase/firefox-android/ship_android
+    - project:releng:services/shipit_api/dev/schedule_phase/firefox-android/promote_android
     - project:releng:services/shipit_api/rebuild_product_details
     - project:releng:services/shipit_api/schedule_phase/devedition/ship_devedition
     - project:releng:services/shipit_api/schedule_phase/firefox/ship_firefox
     - project:releng:services/shipit_api/schedule_phase/firefox-android/ship_android
+    - project:releng:services/shipit_api/schedule_phase/firefox-android/promote_android
     - project:releng:services/shipit_api/staging/add_release/devedition
     - project:releng:services/shipit_api/staging/add_release/firefox
     - project:releng:services/shipit_api/staging/add_release/firefox-android
     - project:releng:services/shipit_api/staging/schedule_phase/devedition/ship_devedition
     - project:releng:services/shipit_api/staging/schedule_phase/firefox/ship_firefox
     - project:releng:services/shipit_api/staging/schedule_phase/firefox-android/ship_android
+    - project:releng:services/shipit_api/staging/schedule_phase/firefox-android/promote_android
     - project:releng:services/shipit_api/update_release_status
     - queue:claim-work:scriptworker-k8s/gecko-1-shipit-dev
     - queue:worker-id:gecko-1-shipit-dev/gecko-1-shipit-dev-*
@@ -1008,16 +1011,19 @@ project/releng/scriptworker/v2/shipit/prod/firefoxci-gecko-1:
     - project:releng:services/shipit_api/dev/schedule_phase/devedition/ship_devedition
     - project:releng:services/shipit_api/dev/schedule_phase/firefox/ship_firefox
     - project:releng:services/shipit_api/dev/schedule_phase/firefox-android/ship_android
+    - project:releng:services/shipit_api/dev/schedule_phase/firefox-android/promote_android
     - project:releng:services/shipit_api/rebuild_product_details
     - project:releng:services/shipit_api/schedule_phase/devedition/ship_devedition
     - project:releng:services/shipit_api/schedule_phase/firefox/ship_firefox
     - project:releng:services/shipit_api/schedule_phase/firefox-android/ship_android
+    - project:releng:services/shipit_api/schedule_phase/firefox-android/promote_android
     - project:releng:services/shipit_api/staging/add_release/devedition
     - project:releng:services/shipit_api/staging/add_release/firefox
     - project:releng:services/shipit_api/staging/add_release/firefox-android
     - project:releng:services/shipit_api/staging/schedule_phase/devedition/ship_devedition
     - project:releng:services/shipit_api/staging/schedule_phase/firefox/ship_firefox
     - project:releng:services/shipit_api/staging/schedule_phase/firefox-android/ship_android
+    - project:releng:services/shipit_api/staging/schedule_phase/firefox-android/promote_android
     - project:releng:services/shipit_api/update_release_status
     - queue:claim-work:scriptworker-k8s/gecko-1-shipit
     - queue:worker-id:gecko-1-shipit/gecko-1-shipit-*
@@ -1034,10 +1040,12 @@ project/releng/scriptworker/v2/shipit/prod/firefoxci-gecko-3:
     - project:releng:services/shipit_api/production/schedule_phase/devedition/ship_devedition
     - project:releng:services/shipit_api/production/schedule_phase/firefox/ship_firefox
     - project:releng:services/shipit_api/production/schedule_phase/firefox-android/ship_android
+    - project:releng:services/shipit_api/production/schedule_phase/firefox-android/promote_android
     - project:releng:services/shipit_api/rebuild_product_details
     - project:releng:services/shipit_api/schedule_phase/devedition/ship_devedition
     - project:releng:services/shipit_api/schedule_phase/firefox/ship_firefox
     - project:releng:services/shipit_api/schedule_phase/firefox-android/ship_android
+    - project:releng:services/shipit_api/schedule_phase/firefox-android/promote_android
     - project:releng:services/shipit_api/update_release_status
     - queue:claim-work:scriptworker-k8s/gecko-3-shipit
     - queue:worker-id:gecko-3-shipit/gecko-3-shipit-*


### PR DESCRIPTION
Due to play store review delays, we're not scheduling the ship phase automatically (see
https://hg.mozilla.org/mozilla-central/rev/4bab23e5cf43).