### PR TITLE
bug 1907655: remove l10n bump cron task/hook from mozilla-central

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -313,7 +313,6 @@ mozilla-central:
       - nightly-desktop-win64-aarch64
       - periodic-update
       - system-symbols
-      - l10n-bumper
       - l10n-cross-channel
       - target: scriptworker-canary
         allow-input: true


### PR DESCRIPTION
My understanding is that we don't want to run this directly on mozilla-central anymore. I just did by accident. Unless there's a reason to keep these, let's drop them.

Aryx points out that in an emergency we can run on autoland and graft to central.