### PR TITLE
Bug 1902346: no-scratch worker pools use image with updated livelog cert

### DIFF
--- a/worker-images.yml
+++ b/worker-images.yml
@@ -68,11 +68,11 @@ monopacker-ubuntu-2204-wayland-arm64:
 handbuilt-ubuntu-2204-wayland-vm:
   fxci-level1-gcp: projects/taskcluster-imaging/global/images/generic-2204-wayland-vm-gcp-googlecompute-2023-09-22t17-39-37z
 # d-w tester images are still handbuilt
-handbuilt-docker-worker-tester-20240325:
+# handbuilt-docker-worker-tester-20240325:
   # built off of projects/taskcluster-imaging/global/images/docker-worker-gcp-u14-04-2023-06-13
   # includes fixes to handle instances with no scratch disks attached
   # - see https://github.com/mozilla-platform-ops/relops-infra/tree/master/docker-worker-test-image
-  fxci-level1-gcp: projects/taskcluster-imaging/global/images/docker-worker-gcp-u14-04-2024-03-25
+  # fxci-level1-gcp: projects/taskcluster-imaging/global/images/docker-worker-gcp-u14-04-2024-03-25
 handbuilt-docker-worker-tester-20240614:
   # for relops-993
   # built off of projects/taskcluster-imaging/global/images/docker-worker-gcp-u14-04-2024-03-25

--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -1234,7 +1234,7 @@ pools:
       image:
         by-chain-of-trust:
           trusted: monopacker-docker-worker-trusted-current-gcp
-          default: handbuilt-docker-worker-tester-20240325
+          default: handbuilt-docker-worker-tester-20240614
       instance_types:
         - minCpuPlatform: Intel Cascadelake
           disks:
@@ -1268,7 +1268,7 @@ pools:
       image:
         by-chain-of-trust:
           trusted: monopacker-docker-worker-trusted-current-gcp
-          default: handbuilt-docker-worker-tester-20240325
+          default: handbuilt-docker-worker-tester-20240614
       instance_types:
         - minCpuPlatform: Intel Cascadelake
           disks:
@@ -1309,7 +1309,7 @@ pools:
       minCapacity: 0
       maxCapacity: 400
       regions: [us-central1, us-west1]
-      image: handbuilt-docker-worker-tester-20240325
+      image: handbuilt-docker-worker-tester-20240614
       worker-config:
         deviceManagement:
           kvm:
@@ -1358,7 +1358,7 @@ pools:
       minCapacity: 0
       maxCapacity: 400
       regions: [us-central1, us-west1]
-      image: handbuilt-docker-worker-tester-20240325
+      image: handbuilt-docker-worker-tester-20240614
       worker-config:
         deviceManagement:
           kvm:
@@ -3195,7 +3195,7 @@ pools:
           comm-t: 100
           mozilla-t: 100
       regions: [us-central1, us-west1]
-      image: handbuilt-docker-worker-tester-20240325
+      image: handbuilt-docker-worker-tester-20240614
       instance_types:
         - minCpuPlatform: Intel Cascadelake
           disks:


### PR DESCRIPTION
Testing performed is mentioned in the first half of this change: https://phabricator.services.mozilla.com/D215274.

See https://mozilla-hub.atlassian.net/browse/RELOPS-988 and https://bugzilla.mozilla.org/show_bug.cgi?id=1902346 for more info.