### PR TITLE
reorder codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,7 @@
+# Per https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#   the last match wins, so put the default at the top.
+* @mozilla-releng/releng
+
 clients.yml @mozilla-releng/relops @mozilla-releng/releng
 worker-images.yml @mozilla-releng/relops
 worker-pools.yml @mozilla-releng/relops @mozilla-releng/releng
-* @mozilla-releng/releng


### PR DESCRIPTION
https://github.com/mozilla-releng/fxci-config/pull/27 only added Releng to the review... but I thought it should add Releng and Relops.

This seems to be because CODEOWNERS evaulation uses the last matching rule for choosing reviewers (see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).