### PR TITLE
Setup checkout cache for code review testing hook

### DIFF
--- a/grants.yml
+++ b/grants.yml
@@ -2583,6 +2583,7 @@
 - grant:
     - secrets:get:project/relman/code-review/runtime-testing
     - hooks:trigger-hook:project-relman/code-review-testing
+    - generic-worker:cache:code-review-testing-checkout
   to:
     - roles:
         - project:relman:code-review/runtime/testing

--- a/hooks.yml
+++ b/hooks.yml
@@ -138,6 +138,7 @@ project-relman/code-review-testing:
     - queue:route:notify.email.*
     - queue:scheduler-id:relman
     - secrets:get:project/relman/code-review/runtime-testing
+    - generic-worker:cache:code-review-testing-checkout
   template_file: hooks/project-relman/code-review-testing.yml
   bindings:
     - exchange: exchange/taskcluster-queue/v1/task-completed

--- a/hooks/project-relman/code-review-testing.yml
+++ b/hooks/project-relman/code-review-testing.yml
@@ -16,12 +16,15 @@ payload:
     public/results:
       path: /tmp/results
       type: directory
-  cache: {}
+  cache:
+    code-review-testing-checkout: '/checkouts'
   capabilities: {}
   command:
     - code-review-bot
     - '--taskcluster-secret'
     - project/relman/code-review/runtime-testing
+    - '--mercurial-repository'
+    - '/checkouts'
   env:
     $merge:
       - $if: firedBy == 'triggerHook'
@@ -54,5 +57,6 @@ scopes:
   - 'secrets:get:project/relman/code-review/runtime-testing'
   - 'index:insert-task:project.relman.testing.code-review.*'
   - 'notify:email:*'
+  - 'generic-worker:cache:code-review-testing-checkout'
 tags: {}
 workerType: bot-gcp


### PR DESCRIPTION
Refs https://github.com/mozilla/code-review/issues/2193
Needed for https://github.com/mozilla/code-review/pull/2235

The goal here is to use Taskcluster cache on the firefox-ci [code-review testing hook](https://firefox-ci-tc.services.mozilla.com/hooks/project-relman/code-review-testing) so that mercurial checkouts can be shared amongst tasks.

I'm not sure if I need to declare that scope in `grants.yml` for the hook or if it's assigned automatically.