### PR TITLE
grant `queue:route:index.xpi.cache.pr.*` to mozilla-extensions repos

### DIFF
--- a/grants.yml
+++ b/grants.yml
@@ -1945,6 +1945,7 @@
     - queue:route:index.xpi.xpi-manifest.cache.level-1.*
     - queue:route:index.xpi.v2.*
     - queue:route:index.xpi.cache.level-1.*
+    - queue:route:index.xpi.cache.pr.*
     - queue:route:checks
     - queue:scheduler-id:taskcluster-github
     - queue:route:notify.email.*


### PR DESCRIPTION
taskgraph 7 added caches for pull requests (and taskgraph 8 changed the index path)