### PR TITLE
Bug 1908773 - Create a L1 images-gcp-aarch64 worker pool

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -1119,6 +1119,35 @@ pools:
                 - *scratch-disk
               machine_type: c2-standard-4
               capacityPerInstance: 1
+  - pool_id: '{pool-group}/images-gcp-aarch64'
+    description: Builds AArch64 docker images
+    owner: release+tc-workers@mozilla.com
+    variants:
+      - pool-group: gecko-1
+    email_on_error: false
+    provider_id:
+      by-chain-of-trust:
+        trusted: fxci-level3-gcp
+        default: fxci-level1-gcp
+    config:
+      minCapacity: 0
+      maxCapacity:
+        by-pool-group:
+          gecko-.*: 10
+      implementation: generic-worker/worker-runner-linux-multi
+      # the "t2a" machine series is only available in the "a", "b", and "f" zones of the "us-central1" region.
+      regions: [us-central1]
+      image: monopacker-ubuntu-2204-wayland-arm64
+      security:
+        by-chain-of-trust:
+          trusted: trusted
+          default:
+      instance_types:
+        - minCpuPlatform: Ampere Altra
+          disks:
+            - <<: *persistent-disk
+              diskSizeGb: 75
+          machine_type: t2a-standard-4
   - pool_id: '{pool-group}/t-linux-xlarge{suffix}-gcp'
     description: Worker for gecko-based automation.
     owner: release+tc-workers@mozilla.com


### PR DESCRIPTION
[Bug 1908773: Create images-gcp-aarch64 pool to provision an appropiate instance type for image tasks](https://bugzilla.mozilla.org/show_bug.cgi?id=1908773)