### PR TITLE
Bug 1908850 - cleanup aws-s3 sccache grants

### DIFF
--- a/grants.yml
+++ b/grants.yml
@@ -151,60 +151,36 @@
         alias: maple
 
 - grant:
-    - auth:aws-s3:read-write:comm-central-level-1-sccache-eu-central-1/*
-    - auth:aws-s3:read-write:comm-central-level-1-sccache-us-east-1/*
-    - auth:aws-s3:read-write:comm-central-level-1-sccache-us-west-1/*
-    - auth:aws-s3:read-write:comm-central-level-1-sccache-us-west-2/*
     - auth:gcp:access-token:sccache-3/comm-sccache-l1*
   to:
     - role:
         - project:taskcluster:comm:level-1-sccache-buckets
 
 - grant:
-    - auth:aws-s3:read-write:comm-central-level-2-sccache-eu-central-1/*
-    - auth:aws-s3:read-write:comm-central-level-2-sccache-us-east-1/*
-    - auth:aws-s3:read-write:comm-central-level-2-sccache-us-west-1/*
-    - auth:aws-s3:read-write:comm-central-level-2-sccache-us-west-2/*
     - auth:gcp:access-token:sccache-3/comm-sccache-l2*
   to:
     - role:
         - project:taskcluster:comm:level-2-sccache-buckets
 
 - grant:
-    - auth:aws-s3:read-write:comm-central-level-3-sccache-eu-central-1/*
-    - auth:aws-s3:read-write:comm-central-level-3-sccache-us-east-1/*
-    - auth:aws-s3:read-write:comm-central-level-3-sccache-us-west-1/*
-    - auth:aws-s3:read-write:comm-central-level-3-sccache-us-west-2/*
     - auth:gcp:access-token:sccache-3/comm-sccache-l3*
   to:
     - role:
         - project:taskcluster:comm:level-3-sccache-buckets
 
 - grant:
-    - auth:aws-s3:read-write:taskcluster-level-1-sccache-eu-central-1/*
-    - auth:aws-s3:read-write:taskcluster-level-1-sccache-us-east-1/*
-    - auth:aws-s3:read-write:taskcluster-level-1-sccache-us-west-1/*
-    - auth:aws-s3:read-write:taskcluster-level-1-sccache-us-west-2/*
     - auth:gcp:access-token:sccache-3/sccache-l1*
   to:
     - role:
         - project:taskcluster:gecko:level-1-sccache-buckets
 
 - grant:
-    - auth:aws-s3:read-write:taskcluster-level-2-sccache-eu-central-1/*
-    - auth:aws-s3:read-write:taskcluster-level-2-sccache-us-east-1/*
-    - auth:aws-s3:read-write:taskcluster-level-2-sccache-us-west-1/*
-    - auth:aws-s3:read-write:taskcluster-level-2-sccache-us-west-2/*
     - auth:gcp:access-token:sccache-3/sccache-l2*
   to:
     - role:
         - project:taskcluster:gecko:level-2-sccache-buckets
 
 - grant:
-    - auth:aws-s3:read-write:taskcluster-level-3-sccache-eu-central-1/*
-    - auth:aws-s3:read-write:taskcluster-level-3-sccache-us-east-1/*
-    - auth:aws-s3:read-write:taskcluster-level-3-sccache-us-west-1/*
-    - auth:aws-s3:read-write:taskcluster-level-3-sccache-us-west-2/*
     - auth:gcp:access-token:sccache-3/sccache-l3*
   to:
     - role:


### PR DESCRIPTION
builds moved from aws to gcp in bug 1757601, so we shouldn't be using s3 for sccache anymore.