### PR TITLE
Use docker-worker cache for code-review testing hook

### DIFF
--- a/grants.yml
+++ b/grants.yml
@@ -2559,7 +2559,7 @@
 - grant:
     - secrets:get:project/relman/code-review/runtime-testing
     - hooks:trigger-hook:project-relman/code-review-testing
-    - generic-worker:cache:code-review-testing-checkout
+    - docker-worker:cache:code-review-testing-checkout
   to:
     - roles:
         - project:relman:code-review/runtime/testing

--- a/hooks.yml
+++ b/hooks.yml
@@ -138,7 +138,7 @@ project-relman/code-review-testing:
     - queue:route:notify.email.*
     - queue:scheduler-id:relman
     - secrets:get:project/relman/code-review/runtime-testing
-    - generic-worker:cache:code-review-testing-checkout
+    - docker-worker:cache:code-review-testing-checkout
   template_file: hooks/project-relman/code-review-testing.yml
   bindings:
     - exchange: exchange/taskcluster-queue/v1/task-completed

--- a/hooks/project-relman/code-review-testing.yml
+++ b/hooks/project-relman/code-review-testing.yml
@@ -57,6 +57,6 @@ scopes:
   - 'secrets:get:project/relman/code-review/runtime-testing'
   - 'index:insert-task:project.relman.testing.code-review.*'
   - 'notify:email:*'
-  - 'generic-worker:cache:code-review-testing-checkout'
+  - 'docker-worker:cache:code-review-testing-checkout'
 tags: {}
 workerType: bot-gcp


### PR DESCRIPTION
Followup https://github.com/mozilla-releng/fxci-config/pull/32#issuecomment-2238828444

This should fix the scope issue currently produced on [code-review-testing hook](https://firefox-ci-tc.services.mozilla.com/hooks/project-relman/code-review-testing) (sample [task](https://firefox-ci-tc.services.mozilla.com/tasks/H54Y9g22RlmSiXERiCazQw/runs/0/logs/public/logs/live.log)).


