### PR TITLE
Add a `docker-compose run --rm ci-admin` command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:latest
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TASKCLUSTER_ROOT_URL=https://firefox-ci-tc.services.mozilla.com/
+
+RUN apt update && \
+    apt install -y software-properties-common curl git
+
+RUN add-apt-repository ppa:deadsnakes/ppa && \
+    apt update && \
+    apt install -y python3.11 python3.11-venv python3.11-dev
+
+RUN curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+    python3.11 get-pip.py && \
+    rm get-pip.py
+
+WORKDIR /home/fxci-config
+
+RUN mkdir -p /home/fxci-config/requirements
+
+COPY requirements/*.txt /home/fxci-config/requirements/
+
+RUN python3.11 -m pip install -r /home/fxci-config/requirements/test.txt
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.8'
+
+services:
+  ci-admin:
+    build: .
+    volumes:
+      - .:/home/fxci-config
+    working_dir: /home/fxci-config

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+python3.11 -m pip install --root-user-action=ignore -e .
+
+ci-admin "$@"


### PR DESCRIPTION
This commit introduces a new docker-compose command to run the ci-admin tool.

Note: If the `requirements/test.txt` file changes, the Docker image needs to be rebuilt to include the updated dependencies.

Example:
```sh
docker-compose run --rm ci-admin check --environment firefoxci 2>&1 | tee check.out
```