### PR TITLE
bug 1907217: remove * star branches from remaining github repositories

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -694,8 +694,6 @@ reference-browser:
   trust_project: reference-browser
   repo_type: git
   branches:
-    - name: "*"
-      level: 3
     - name: master
       level: 3
   default_branch: master
@@ -727,8 +725,6 @@ firefox-ios:
   trust_project: firefox-ios
   repo_type: git
   branches:
-    - name: "*"
-      level: 3
     - name: main
       level: 3
   features:
@@ -754,8 +750,6 @@ staging-firefox-ios:
   trust_project: firefox-ios
   repo_type: git
   branches:
-    - name: "*"
-      level: 1
     - name: main
       level: 1
   features:
@@ -774,9 +768,9 @@ application-services:
   repo: https://github.com/mozilla/application-services
   repo_type: git
   branches:
-    - name: "*"
-      level: 3
     - name: main
+      level: 3
+    - name: "release-*"
       level: 3
   trust_domain: app-services
   features:
@@ -798,9 +792,9 @@ staging-application-services:
   repo: https://github.com/mozilla-releng/staging-application-services
   repo_type: git
   branches:
-    - name: "*"
-      level: 1
     - name: main
+      level: 1
+    - name: "release-*"
       level: 1
   trust_domain: app-services
   features:
@@ -818,8 +812,6 @@ glean:
   repo: https://github.com/mozilla/glean
   repo_type: git
   branches:
-    - name: "*"
-      level: 3
     - name: main
       level: 3
   trust_domain: glean
@@ -861,9 +853,11 @@ product-details:
   repo_type: git
   trust_domain: releng
   branches:
-    - name: "*"
-      level: 3
+    # We don't do anything on `main`, but some code requires us to have a level
+    # set for it.
     - name: main
+      level: 1
+    - name: testing
       level: 3
     - name: production
       level: 3
@@ -1016,8 +1010,6 @@ cloud-image-builder:
   repo: https://github.com/mozilla-platform-ops/cloud-image-builder
   repo_type: git
   branches:
-    - name: "*"
-      level: 3
     - name: main
       level: 3
   trust_domain: relops
@@ -1076,8 +1068,6 @@ xpi-manifest:
   repo: https://github.com/mozilla-extensions/xpi-manifest
   repo_type: git
   branches:
-    - name: "*"
-      level: 3
     - name: main
       level: 3
   trust_domain: xpi
@@ -1158,8 +1148,6 @@ adhoc-signing:
   repo: https://github.com/mozilla-releng/adhoc-signing
   repo_type: git
   branches:
-    - name: "*"
-      level: 3
     - name: main
       level: 3
   trust_domain: adhoc
@@ -1176,9 +1164,15 @@ code-review:
   repo: https://github.com/mozilla/code-review
   repo_type: git
   branches:
-    - name: "*"
+    - name: production
       level: 3
+    # Ideally `master` and `testing` would be level 1, but there are no L1
+    # and L3 pools for the tasks that the code-review hooks generate, so
+    # there's no benefit to doing that at this point, as L1 and L3 tasks
+    # would end up on the same workers anyways.
     - name: master
+      level: 3
+    - name: testing
       level: 3
   default_branch: master
   trust_domain: code-analysis
@@ -1212,9 +1206,15 @@ code-coverage:
   repo: https://github.com/mozilla/code-coverage
   repo_type: git
   branches:
-    - name: "*"
+    - name: production
       level: 3
+    # Ideally `master` and `testing` would be level 1, but there are no L1
+    # and L3 pools for the tasks that the code-review hooks generate, so
+    # there's no benefit to doing that at this point, as L1 and L3 tasks
+    # would end up on the same workers anyways.
     - name: master
+      level: 3
+    - name: testing
       level: 3
   default_branch: master
   trust_domain: code-analysis
@@ -1228,9 +1228,11 @@ firefox-translations-training:
   repo: https://github.com/mozilla/firefox-translations-training
   repo_type: git
   branches:
-    - name: "*"
-      level: 1
     - name: main
+      level: 1
+    - name: "release*"
+      level: 1
+    - name: "dev*"
       level: 1
   trust_domain: translations
   # https://github.com/mozilla/firefox-translations-training/issues/206


### PR DESCRIPTION
This depends on a handful of PRs to these repos:
https://github.com/mozilla-mobile/reference-browser/pull/2982
https://github.com/mozilla-mobile/firefox-ios/pull/21357
https://github.com/mozilla/code-review/pull/2289
https://github.com/mozilla/code-coverage/pull/2408
https://github.com/mozilla/firefox-translations-training/pull/777
https://github.com/mozilla-platform-ops/cloud-image-builder/pull/21
https://github.com/mozilla-releng/adhoc-signing/pull/213
https://github.com/mozilla-extensions/xpi-manifest/pull/235

After this change, the only Github repositories with `*` branches will be `staging` repositories, as was discussed in https://github.com/mozilla-releng/fxci-config/pull/18.