### PR TITLE
chore: drop support for Python 3.9

### DIFF
--- a/maintenance/pin.sh
+++ b/maintenance/pin.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 # Pin all requirements.
 #
-# As of this writing, cloudops-jenkins uses an image based off of python:3.9
-# to run ci-admin
-#
 # To test, after running maintenance/pin.sh:
 #
 #    docker pull gcr.io/moz-fx-cloudops-images-global/cloudops-infra-deploylib:2
@@ -16,5 +13,5 @@
 set -e
 set -x
 
-docker run --rm -ti -v $PWD:/src -w /src python:3.9 maintenance/pin-helper.sh
+docker run --rm -ti -v $PWD:/src -w /src python:3.11 maintenance/pin-helper.sh
 docker run --rm -ti -v $PWD:/src -w /src/build-decision python:3.11 ../maintenance/pin-helper.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 88
-target-version = ["py37", "py38"]
+target-version = ["py311"]
 include = '\.(wsgi|pyi?)$'
 exclude = '''
 /(

--- a/taskcluster/docker/python/Dockerfile
+++ b/taskcluster/docker/python/Dockerfile
@@ -3,8 +3,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # %ARG PYTHON_VERSION
-FROM          python:$PYTHON_VERSION
-MAINTAINER    Tom Prince <tom.prince@mozilla.com>
+FROM python:$PYTHON_VERSION
+LABEL maintainer="Mozilla Release Engineering <release+fxci-config@mozilla.com>"
 
 # Add worker user
 RUN mkdir /builds && \

--- a/taskcluster/kinds/docker-image/kind.yml
+++ b/taskcluster/kinds/docker-image/kind.yml
@@ -20,10 +20,6 @@ tasks:
         definition: build-decision
         args:
             PYTHON_VERSION: "3.11"
-    python3.9:
-        definition: python
-        args:
-            PYTHON_VERSION: "3.9"
     python3.11:
         definition: python
         args:

--- a/taskcluster/kinds/tests/kind.yml
+++ b/taskcluster/kinds/tests/kind.yml
@@ -14,7 +14,7 @@ task-defaults:
         code-review: true
     worker-type: t-linux
     worker:
-        docker-image: {in-tree: python3.9}
+        docker-image: {in-tree: python3.11}
         max-run-time: 3600
     run:
         cwd: '{checkout}'

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,8 @@ passenv =
     PYTHON_VERSION
     TOXENV
 setenv =
-    PYTHON_VERSION=3.9
-    TOXENV=check,py39
+    PYTHON_VERSION=3.11
+    TOXENV=check,py311
 deps =
 usedevelop = false
 depends =
@@ -45,7 +45,7 @@ depends =
 [testenv:report]
 skip_install = true
 commands = coverage report -m
-depends = py39
+depends = py311
 parallel_show_output = true
 
 [testenv:check]


### PR DESCRIPTION
Previously the Jenkins job was using Python 3.9, thus why we were running tests there. Now that we're using Github Actions to deploy, we should test against the same version that uses instead (3.11).