### PR TITLE
change scm_level of oak project to 3

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -193,7 +193,7 @@ comm-esr128:
 oak:
   repo: https://hg.mozilla.org/projects/oak
   repo_type: hg
-  access: scm_level_1
+  access: scm_level_3
   branches:
     - name: "*"
     - name: default


### PR DESCRIPTION
@kaya contacted me to request this change. 

I have verified that `https://hg.mozilla.org/projects/oak/json-repoinfo` reports scm_level_3.