### PR TITLE
Bug 1912260 - revert grants for Fenix beta builds on oak

### DIFF
--- a/grants.yml
+++ b/grants.yml
@@ -507,14 +507,6 @@
         level: [3]
         alias: [mozilla-esr128, mozilla-esr115, mozilla-release, mozilla-beta]
 
-# temporarily enable beta builds on oak, for bug 1912032
-- grant:
-    - project:releng:signing:cert:fennec-production-signing
-    - secrets:get:project/mobile/firefox-android/fenix/beta
-  to:
-    - projects:
-        alias: [oak]
-
 - grant:
     - project:releng:googleplay:product:fenix
     - project:releng:googleplay:product:focus-android


### PR DESCRIPTION
Reverts #56 (should no longer be needed)