### PR TITLE
Remove aws provisioner references

### DIFF
--- a/grants.yml
+++ b/grants.yml
@@ -977,14 +977,6 @@
           - pr-actions
 
 - grant:
-    - queue:create-task:low:aws-provisioner-v1/gecko-{level}-decision
-    - queue:create-task:low:aws-provisioner-v1/gecko-misc
-    - queue:create-task:low:aws-provisioner-v1/gecko-{level}-images
-  to:
-    - project:
-        trust_domain: [taskgraph, ci]
-
-- grant:
     - secrets:get:project/releng/taskgraph/ci
   to:
     - project:

--- a/src/ciadmin/check/check_hg_push_scopes.py
+++ b/src/ciadmin/check/check_hg_push_scopes.py
@@ -51,9 +51,9 @@ def create_task_scopes(queue_priorities):
     All scopes that could allow creating a task on the hg-push workerType
     """
     return [
-        f"queue:create-task:{priority}:aws-provisioner-v1/hg-push"
+        f"queue:create-task:{priority}:infra/build-decision"
         for priority in queue_priorities
-    ] + ["queue:create-task:aws-provisioner-v1/hg-push"]
+    ] + ["queue:create-task:infra/build-decision"]
 
 
 def check_ci_groups_create_task(ci_group_roles, create_task_scopes):


### PR DESCRIPTION
These have been obsolete for about 5 years.