### PR TITLE
Bug 1913152 - Grant create-task scopes for releng-hardware to trust d…

### DIFF
--- a/grants.yml
+++ b/grants.yml
@@ -853,6 +853,7 @@
     # Allow creating tasks on workers associated to the trust-domain
     - queue:create-task:{priority}:{trust_domain}-{level}/*
     - queue:create-task:{priority}:{trust_domain}-t/*
+    - queue:create-task:{priority}:releng-hardware/{trust_domain}-b-{level}-*
     - queue:create-task:{priority}:built-in/*
   to:
     - project:
@@ -1652,7 +1653,6 @@
 # Mozilla VPN
 
 - grant:
-    - queue:create-task:{priority}:releng-hardware/mozillavpn-b-{level}-*
     - queue:create-task:{priority}:scriptworker-prov-v1/mozillavpn-{level}-*
     # TODO: remove extraneous 'mozillavpn' from this route
     - queue:route:index.{trust_domain}.v2.mozillavpn.cache.level-{level}.*

--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -2243,6 +2243,7 @@ pools:
       - pool-group: comm-2
       - pool-group: comm-3
         chain-of-trust: trusted
+      - pool-group: mozilla-1
       - pool-group: mozillavpn-1
       - pool-group: mozillavpn-3
         chain-of-trust: trusted
@@ -2270,6 +2271,7 @@ pools:
           comm-3: 50
           comm-(1|2): 25
           mozillavpn-.*: 25
+          mozilla-.*: 25
           relops-.*: 12
       worker-purpose:
         by-pool-group:


### PR DESCRIPTION
…omains implicitly

Obviously the vast majority of trust domains don't have any `releng-hardware` so this is going to add a bunch of unnecessary scopes. But they shouldn't cause any problems or harm and this will make things a little smoother for the next project that needs to use a worker with this pattern.