### PR TITLE
ci: add client capable of generating the tc config

### DIFF
--- a/clients.yml
+++ b/clients.yml
@@ -247,6 +247,11 @@ project/releng/fxci-config/apply:
   description: Used to run `tc-admin apply` in mozilla-releng/fxci-config.
   scopes:
     - "*"
+project/releng/fxci-config/generate:
+  description: Used to run `tc-admin {generate|diff}` in mozilla-releng/fxci-config.
+  scopes:
+    - auth:list:clients
+    - hooks:list-hooks:*
 project/releng/generic-worker/azure-gecko-1-b-win2012:
   description: Windows 2012 experimental production worker.
   scopes:


### PR DESCRIPTION
This is going to be used in a task that runs `tc-admin diff` in fxci-config's CI.