### PR TITLE
bump max capacity of t-linux-kvm-noscratch-gcp

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -1342,7 +1342,7 @@ pools:
     provider_id: fxci-level1-gcp
     config:
       minCapacity: 0
-      maxCapacity: 400
+      maxCapacity: 800
       regions: [us-central1, us-west1]
       image: handbuilt-docker-worker-tester-20240614
       worker-config:


### PR DESCRIPTION
This pool can get highly backed up at times; let's bump the max capacity. This shouldn't affect cost at all, merely get things done sooner.