### PR TITLE
feat: add support for in tree actions from all configured branches

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ jobs:
         environment: ["staging", "firefoxci"]
     env:
       TASKCLUSTER_ROOT_URL: ${{vars.TASKCLUSTER_ROOT_URL}}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -48,6 +49,7 @@ jobs:
       TASKCLUSTER_ROOT_URL: ${{vars.TASKCLUSTER_ROOT_URL}}
       TASKCLUSTER_CLIENT_ID: ${{vars.TASKCLUSTER_CLIENT_ID}}
       TASKCLUSTER_ACCESS_TOKEN: ${{secrets.TASKCLUSTER_ACCESS_TOKEN}}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/src/ciadmin/boot.py
+++ b/src/ciadmin/boot.py
@@ -47,4 +47,8 @@ appconfig.description_prefix = (
 
 
 def boot():
+    if not os.environ.get("GITHUB_TOKEN"):
+        print(
+            "WARNING: GITHUB_TOKEN is not present in the environment; you may run into rate limits querying for GitHub branches"
+        )
     main(appconfig)

--- a/src/ciadmin/generate/branches.py
+++ b/src/ciadmin/generate/branches.py
@@ -1,0 +1,72 @@
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+from asyncio import Lock
+
+import aiohttp
+from aiohttp_retry import ExponentialRetry, RetryClient
+from tcadmin.util.sessions import aiohttp_session
+
+_cache = {}
+_lock = {}
+
+
+# TODO: support private repositories. this will most likely require querying
+# GitHub as an app.
+async def get(repo_path, repo_type="git"):
+    """Get the list of branches present in `repo_path`. Only supported for
+    public GitHub repositories."""
+    if repo_type != "git":
+        raise Exception("Branches can only be fetched for git repositories!")
+
+    if repo_path.endswith("/"):
+        repo_path = repo_path[:-1]
+    branches_url = f"https://api.github.com/repos/{repo_path}/branches"
+
+    # 100 is the maximum allowed
+    # https://docs.github.com/en/rest/branches/branches?apiVersion=2022-11-28#list-branches
+    params = {"per_page": 100}
+    headers = {}
+    if "GITHUB_TOKEN" in os.environ:
+        github_token = os.environ["GITHUB_TOKEN"]
+        headers["Authorization"] = f"Bearer {github_token}"
+
+    async with _lock.setdefault(repo_path, Lock()):
+        if repo_path in _cache:
+            return _cache[repo_path]
+
+        branches = []
+        client = RetryClient(
+            client_session=aiohttp_session(),
+            retry_options=ExponentialRetry(attempts=5),
+        )
+        while branches_url:
+            async with client.get(
+                branches_url, headers=headers, params=params
+            ) as response:
+                try:
+                    response.raise_for_status()
+                    result = await response.json()
+                    branches.extend([b["name"] for b in result])
+                    # If `link` is present in the response it will contain
+                    # pagination information. We need to examine it to see
+                    # if there are additional pages of results to fetch.
+                    # See https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api?apiVersion=2022-11-28#using-link-headers
+                    # for a full description of the responses.
+                    # This icky parsing can probably go away when we switch
+                    # to a GitHub app, as we'll likely be using a proper
+                    # client at that point.
+                    for l in response.headers.get("link", "").split(","):
+                        if 'rel="next"' in l:
+                            branches_url = l.split(">")[0].split("<")[1]
+                            break
+                    else:
+                        branches_url = None
+                except aiohttp.ClientResponseError as e:
+                    print(f"Got error when querying {branches_url}: {e}")
+                    raise e
+
+        _cache[repo_path] = branches
+        return _cache[repo_path]


### PR DESCRIPTION
I believe this change is overall a good one, but it has some possibly controversial aspects and/or downsides. I'm interested in any and all feedback or pushback. There might be some ways this can be done without some or all of the downsides.

Most notably, this change more or less requires that a `GITHUB_TOKEN` is set in the environment to run `ci-admin` successfully, otherwise you'll run into rate limits when branches are fetched from Github.

The other, less serious, downside is because we generate hooks for all globbed branches, we end up generating many, many superfluous ones for repos like https://github.com/mozilla/application-services, which have many old and now-unused release branches. One way we could improve this is to _not_ use the `branches` list to determine which branches get action hooks, but have them specified separately. This has its own downside of requiring us to maintain a separate list, and possibly not working automatically when new release branches are created.

The `ci-admin diff` for this is giant and weird because so many new hooks are being created. One thing I did for additional sanity checking was to diff the list of resource names, which showed [a whole bunch of new hooks being added](https://gist.github.com/bhearsum/885e7be7f17f63467b76ef733c5ca3c2). I'd like to diff hook bodies as well, but https://bugzilla.mozilla.org/show_bug.cgi?id=1905339 is making that difficult.

This is built on a few other PRs; only the most recent 3 commits are the relevant changes.