### PR TITLE
Bug 1862675 - switch some gecko linux test pools to c2 instance type

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -3258,7 +3258,7 @@ pools:
                 diskType: diskTypes/local-ssd
               type: SCRATCH
               interface: NVME
-          machine_type: n2-standard-2
+          machine_type: c2-standard-4
   - pool_id: '{pool-group}/t-linux-large-noscratch-gcp'
     description: Worker for gecko-based automation.
     owner: release+tc-workers@mozilla.com
@@ -3286,7 +3286,7 @@ pools:
                 diskSizeGb: 75
                 sourceImage: <image>
               type: PERSISTENT
-          machine_type: n2-standard-2
+          machine_type: c2-standard-4
   - pool_id: '{pool-group}/t-dagger-experimental'  # bug 1906337
     description: Worker for running dagger.io pipelines in Taskcluster
     owner: release+tc-workers@mozilla.com
@@ -3331,63 +3331,6 @@ pools:
               type: SCRATCH
               interface: NVME
           machine_type: n2-standard-2
-  - pool_id: '{pool-group}/t-linux-large-gcp-bug1862675'
-    description: Worker for gecko-based automation.
-    owner: release+tc-workers@mozilla.com
-    provider_id: fxci-level1-gcp
-    variants:
-      - pool-group: gecko-t
-    email_on_error: true
-    config:
-      minCapacity: 0
-      maxCapacity:
-        by-pool-group:
-          gecko-t: 2500
-          comm-t: 100
-          mozilla-t: 100
-      regions: [us-central1, us-west1]
-      image: monopacker-docker-worker-gcp-current
-      instance_types:
-        - minCpuPlatform: Intel Cascadelake
-          disks:
-            - autoDelete: true
-              boot: true
-              initializeParams:
-                diskSizeGb: 75
-                sourceImage: <image>
-              type: PERSISTENT
-            - autoDelete: true
-              initializeParams:
-                diskType: diskTypes/local-ssd
-              type: SCRATCH
-              interface: NVME
-          machine_type: c2-standard-4
-  - pool_id: '{pool-group}/t-linux-large-noscratch-gcp-bug1862675'
-    description: Worker for gecko-based automation.
-    owner: release+tc-workers@mozilla.com
-    provider_id: fxci-level1-gcp
-    variants:
-      - pool-group: gecko-t
-    email_on_error: true
-    config:
-      minCapacity: 0
-      maxCapacity:
-        by-pool-group:
-          gecko-t: 2500
-          comm-t: 100
-          mozilla-t: 100
-      regions: [us-central1, us-west1]
-      image: handbuilt-docker-worker-tester-20240614
-      instance_types:
-        - minCpuPlatform: Intel Cascadelake
-          disks:
-            - autoDelete: true
-              boot: true
-              initializeParams:
-                diskSizeGb: 75
-                sourceImage: <image>
-              type: PERSISTENT
-          machine_type: c2-standard-4
   - pool_id: relops-3/win2019
     description: build windows cloud images for taskcluster windows workloads
     owner: relops-aws-provisioning@mozilla.com

--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -1525,29 +1525,6 @@ pools:
           disks:
             - <<: *persistent-disk
               diskSizeGb: 60
-          machine_type: n2-standard-2
-  - pool_id: '{pool-group}/t-linux-2204-wayland-bug1862675'
-    variants:
-      - pool-group: gecko-t
-    description: Worker for Wayland on Ubuntu 22.04
-    owner: release+tc-workers@mozilla.com
-    email_on_error: true
-    provider_id: fxci-level1-gcp
-    config:
-      worker-config:
-        genericWorker:
-          config:
-            enableInteractive: true  # ok for l1, but not ok for l3?
-      minCapacity: 0
-      maxCapacity: 100
-      implementation: generic-worker/worker-runner-linux-multi
-      regions: [us-central1, us-west1]
-      image: monopacker-ubuntu-2204-wayland
-      instance_types:
-        - minCpuPlatform: Intel Cascadelake
-          disks:
-            - <<: *persistent-disk
-              diskSizeGb: 60
           machine_type: c2-standard-4
   - pool_id: 'gecko-t/t-linux-2204-wayland-root-exp'  # Bug 1874877
     description: Worker for testing Wayland on Ubuntu 22.04

--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -1592,7 +1592,7 @@ pools:
           disks:
             - <<: *persistent-disk
               diskSizeGb: 60
-          machine_type: c2-standard-4
+          machine_type: c2-standard-8
   - pool_id: '{pool-group}/b-linux-v100-gpu'
     description: Worker for machine learning and other high GPU tasks
     owner: release+tc-workers@mozilla.com


### PR DESCRIPTION
List spot prices for c2-standard-4 in both us-west1 and us-central1 have been consistently slightly above n2-standard-2 over the last year (e.g. ~13% right now), for twice the CPU/RAM.

Many test tasks running on n2-standard-2 end up CPU bound; switching to c2-standard-4 means 1) twice as many cores, 2) slightly faster cores, which should help both mono- and multi-threaded workloads. Based on an experiment on try, that should be offsetting the cost difference.