### PR TITLE
Bug 1915192 - grant missing scopes to mozilla-vpn-client action tasks

### DIFF
--- a/grants.yml
+++ b/grants.yml
@@ -1717,10 +1717,6 @@
     - project:
         alias:
           - mozilla-vpn-client
-        job:
-          - branch:*
-          - pull-request:*
-          - release:*
 
 - grant:
     - project:{trust_domain}:releng:signing:format:*


### PR DESCRIPTION
tc-admin diff:

```
@@ -124018,25 +124018,33 @@ Role=repo:github.com/mozilla-mobile/mozilla-vpn-client:action:*:

       Scopes in this role are defined in [fxci-config/grants.yml](https://github.com/mozilla-releng/fxci-config/blob/main/grants.yml).
     scopes:
       - docker-worker:cache:mozillavpn-level-3-*
       - generic-worker:cache:mozillavpn-level-3-*
       - in-tree:hook-action:project-mozillavpn/in-tree-action-3-*
       - index:insert-task:mozillavpn.cache.level-3.*
       - index:insert-task:mozillavpn.v2.mozilla-vpn-client.*
+      - project:mozillavpn:releng:beetmover:action:import-from-gcs-to-artifact-registry
+      - project:mozillavpn:releng:beetmover:action:push-to-candidates
+      - project:mozillavpn:releng:beetmover:apt-repo:dep
+      - project:mozillavpn:releng:beetmover:bucket:dep
+      - project:mozillavpn:releng:signing:cert:dep-signing
       - project:mozillavpn:releng:signing:format:*
       - project:releng:services/tooltool/api/download/internal
       - project:releng:services/tooltool/api/download/public
       - queue:cancel-task:mozillavpn-level-3/*
       - queue:create-task:highest:built-in/*
       - queue:create-task:highest:mozillavpn-3/*
       - queue:create-task:highest:mozillavpn-t/*
       - queue:create-task:highest:releng-hardware/mozillavpn-b-3-*
+      - queue:create-task:highest:scriptworker-k8s/mozillavpn-3-*
+      - queue:create-task:highest:scriptworker-k8s/mozillavpn-t-*
       - queue:create-task:highest:scriptworker-prov-v1/mozillavpn-3-*
+      - queue:create-task:highest:scriptworker-prov-v1/mozillavpn-t-*
       - queue:get-artifact:project/mozillavpn/*
       - queue:rerun-task:mozillavpn-level-3/*
       - queue:route:checks
       - queue:route:index.mozillavpn.cache.level-3.*
       - queue:route:index.mozillavpn.v2.mozilla-vpn-client.*
       - queue:route:index.mozillavpn.v2.mozillavpn.cache.level-3.*
       - queue:route:notify.email.*
       - queue:route:tc-treeherder-stage.mozilla-vpn-client.*
```