### PR TITLE
Bug 1915477 - Grant sheriffs ability to quarantine bespoke Gecko hard…

### DIFF
--- a/grants.yml
+++ b/grants.yml
@@ -2076,6 +2076,7 @@
     - queue:quarantine-worker:gecko-t/*
     - queue:quarantine-worker:proj-autophone/gecko-*
     - queue:quarantine-worker:releng-hardware/gecko-*
+    - queue:quarantine-worker:releng-hardware/win11-64-2009-hw/mdc1/*
     - queue:quarantine-worker:mobile-*
     # Allow sheriffs to terminate gecko/mobile related workers
     - worker-manager:remove-worker:gecko-*


### PR DESCRIPTION
…ware pool

This pool is missing the `gecko-` prefix in the name, so our existing grants don't cover it. Relops is filing a ticket to rename it to follow existing conventions, but it might be non-trivial.

So in the meantime, just add the grant explicitly.