### PR TITLE
Update windows tester/builder (L1) with tc 68.0.2

### DIFF
--- a/worker-images.yml
+++ b/worker-images.yml
@@ -186,7 +186,7 @@ ronin-b-windows2022-rd-alpha:
     north-central-us: win2022-64-2009-rd-northcentralus-2022-datacenter-azure-edition
 ronin-b1-windows2022-prod:
   azure2:
-    deployment_id: 16538c1
+    deployment_id: 985a538
     central-us: win2022-64-2009-centralus-2022-datacenter-azure-edition
     east-us: win2022-64-2009-eastus-2022-datacenter-azure-edition
     east-us-2: win2022-64-2009-eastus2-2022-datacenter-azure-edition
@@ -208,7 +208,7 @@ ronin-b3-windows2022-prod:
 # Windows 10
 ronin-t-windows10-64-2009-prod:
   azure2:
-    deployment_id: 74210e2
+    deployment_id: 985a538
     canada-central: win10-64-2009-canadacentral-win10-22h2-avd
     central-india: win10-64-2009-centralindia-win10-22h2-avd
     central-us: win10-64-2009-centralus-win10-22h2-avd
@@ -259,7 +259,7 @@ ronin-t-windows11-64-2009-alpha:
     uk-south: win11-64-2009-uksouth-win11-22h2-avd
 ronin-t-windows11-64-2009-prod:
   azure2:
-    deployment_id: 74210e2
+    deployment_id: 985a538
     canada-central: win11-64-2009-canadacentral-win11-22h2-avd
     central-india: win11-64-2009-centralindia-win11-22h2-avd
     central-us: win11-64-2009-centralus-win11-22h2-avd


### PR DESCRIPTION
Update windows tester and builder (L1) with taskcluster 68.0.2 + use chocolatey to install updated version of git.