### PR TITLE
Revert "Bug 1917007 - Enable taskgraph-cron feature for afranchuk/process-top…"

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -1294,7 +1294,6 @@ process-top-crashes:
     github-pull-request:
       policy: public
     taskgraph-actions: true
-    taskgraph-cron: true
     trust-domain-scopes: true
 
 ###


### PR DESCRIPTION
Reverts mozilla-releng/fxci-config#88

The cron task is erroring out every 15 minutes because the repo doesn't have a .cron.yml yet.