### PR TITLE
Remove south central us region + update cacert.pem

### DIFF
--- a/worker-images.yml
+++ b/worker-images.yml
@@ -185,12 +185,11 @@ ronin-b-windows2022-rd-alpha:
     north-central-us: win2022-64-2009-rd-northcentralus-2022-datacenter-azure-edition
 ronin-b1-windows2022-prod:
   azure2:
-    deployment_id: 985a538
+    deployment_id: db0c108
     central-us: win2022-64-2009-centralus-2022-datacenter-azure-edition
     east-us: win2022-64-2009-eastus-2022-datacenter-azure-edition
     east-us-2: win2022-64-2009-eastus2-2022-datacenter-azure-edition
     north-central-us: win2022-64-2009-northcentralus-2022-datacenter-azure-edition
-    south-central-us: win2022-64-2009-southcentralus-2022-datacenter-azure-edition
     west-us: win2022-64-2009-westus-2022-datacenter-azure-edition
     west-us-2: win2022-64-2009-westus2-2022-datacenter-azure-edition
 ronin-b3-windows2022-prod:
@@ -207,7 +206,7 @@ ronin-b3-windows2022-prod:
 # Windows 10
 ronin-t-windows10-64-2009-prod:
   azure2:
-    deployment_id: 985a538
+    deployment_id: db0c108
     canada-central: win10-64-2009-canadacentral-win10-22h2-avd
     central-india: win10-64-2009-centralindia-win10-22h2-avd
     central-us: win10-64-2009-centralus-win10-22h2-avd
@@ -269,7 +268,7 @@ ronin-t-windows11-64-2009-alpha:
     uk-south: win11-64-2009-uksouth-win11-22h2-avd
 ronin-t-windows11-64-2009-prod:
   azure2:
-    deployment_id: 985a538
+    deployment_id: db0c108
     canada-central: win11-64-2009-canadacentral-win11-22h2-avd
     central-india: win11-64-2009-centralindia-win11-22h2-avd
     central-us: win11-64-2009-centralus-win11-22h2-avd

--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -2209,7 +2209,7 @@ pools:
       implementation: generic-worker/worker-runner-windows
       locations:
         by-pool-group:
-          .*-3: [central-us, south-central-us, east-us-2, west-us-2]
+          .*-3: [central-us, east-us-2, west-us-2]
           default: [central-us, north-central-us, east-us-2, west-us-2]
       maxCapacity:
         by-pool-group:


### PR DESCRIPTION
Per [bug1915855 ](https://bugzilla.mozilla.org/show_bug.cgi?id=1915855) this updates the windows worker pools to an updated cacert.pem file + removes south central us as we keep running into regional quota issues.