### PR TITLE
add new wayland 2204 image and pool to test it

### DIFF
--- a/worker-images.yml
+++ b/worker-images.yml
@@ -34,7 +34,8 @@ monopacker-docker-worker-gcp-current: handbuilt-docker-worker-tester-20240614
 
 # 'image qualification' pool aliases
 monopacker-docker-worker-relops528: monopacker-docker-worker-2023-04-13-relops528
-monopacker-gw-gcp-l1-gui-relops1071: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-gui-googlecompute-2024-08-22t22-48-09z
+monopacker-gw-gcp-l1-gui-relops1071:
+  fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-gui-googlecompute-2024-08-22t22-48-09z
 
 # not used any longer?
 relops-image-builder-current: relops-image-builder-pre

--- a/worker-images.yml
+++ b/worker-images.yml
@@ -34,7 +34,7 @@ monopacker-docker-worker-gcp-current: handbuilt-docker-worker-tester-20240614
 
 # 'image qualification' pool aliases
 monopacker-docker-worker-relops528: monopacker-docker-worker-2023-04-13-relops528
-monopacker-gw-gcp-l1-gui-relops1071:
+monopacker-gw-gcp-wayland-gui-relops1071:
   fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-gui-googlecompute-2024-08-22t22-48-09z
 
 # not used any longer?

--- a/worker-images.yml
+++ b/worker-images.yml
@@ -34,6 +34,7 @@ monopacker-docker-worker-gcp-current: handbuilt-docker-worker-tester-20240614
 
 # 'image qualification' pool aliases
 monopacker-docker-worker-relops528: monopacker-docker-worker-2023-04-13-relops528
+monopacker-gw-gcp-l1-gui-relops1071: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-gui-googlecompute-2024-08-22t22-48-09z
 
 # not used any longer?
 relops-image-builder-current: relops-image-builder-pre

--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -1472,6 +1472,27 @@ pools:
             - <<: *persistent-disk
               diskSizeGb: 60
           machine_type: c2-standard-4
+  - pool_id: 'gecko-t/t-linux-2204-wayland-relsre-image-qual'
+    description: Worker for Wayland on Ubuntu 22.04. Used by RelSRE to qualify images.
+    owner: release+tc-workers@mozilla.com
+    email_on_error: true
+    provider_id: fxci-level1-gcp
+    config:
+      worker-config:
+        genericWorker:
+          config:
+            enableInteractive: true  # ok for l1, but not ok for l3?
+      minCapacity: 0
+      maxCapacity: 2
+      implementation: generic-worker/worker-runner-linux-multi
+      regions: [us-central1, us-west1]
+      image: monopacker-gw-gcp-l1-gui-relops1071
+      instance_types:
+        - minCpuPlatform: Intel Cascadelake
+          disks:
+            - <<: *persistent-disk
+              diskSizeGb: 60
+          machine_type: c2-standard-4
   - pool_id: 'gecko-t/t-linux-2204-wayland-root-exp'  # Bug 1874877
     description: Worker for testing Wayland on Ubuntu 22.04
     owner: release+tc-workers@mozilla.com

--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -1486,7 +1486,7 @@ pools:
       maxCapacity: 10
       implementation: generic-worker/worker-runner-linux-multi
       regions: [us-central1, us-west1]
-      image: monopacker-gw-gcp-l1-gui-relops1071
+      image: monopacker-gw-gcp-wayland-gui-relops1071
       instance_types:
         - minCpuPlatform: Intel Cascadelake
           disks:

--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -1483,7 +1483,7 @@ pools:
           config:
             enableInteractive: true  # ok for l1, but not ok for l3?
       minCapacity: 0
-      maxCapacity: 2
+      maxCapacity: 10
       implementation: generic-worker/worker-runner-linux-multi
       regions: [us-central1, us-west1]
       image: monopacker-gw-gcp-l1-gui-relops1071

--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -1474,7 +1474,7 @@ pools:
           machine_type: c2-standard-4
   - pool_id: 'gecko-t/t-linux-2204-wayland-relsre-image-qual'
     description: Worker for Wayland on Ubuntu 22.04. Used by RelSRE to qualify images.
-    owner: release+tc-workers@mozilla.com
+    owner: aerickson@mozilla.com
     email_on_error: true
     provider_id: fxci-level1-gcp
     config:


### PR DESCRIPTION
Deploys the image created in https://github.com/mozilla-platform-ops/monopacker/pull/146 to an image qualification pool.

- **add new l1 wayland testing image**
- **add pool to use new image being qualified**
