### PR TITLE
Update thunderbird-releng group to use thunderbird_releng LDAP.

### DIFF
--- a/grants.yml
+++ b/grants.yml
@@ -2702,10 +2702,8 @@
     - assume:project:releng:ci-group:thunderbird-releng
   to:
     - roles:
-        # Rob Lemley [:rjl] (https://bugzilla.mozilla.org/show_bug.cgi?id=1496783)
-        - login-identity:mozilla-auth0/ad|Mozilla-LDAP|thunderbird
-        # Daniel Darnell (https://bugzilla.mozilla.org/show_bug.cgi?id=1780090)
-        - login-identity:mozilla-auth0/ad|Mozilla-LDAP|daniel23
+        # Thunderbird release engineering, Corey Bryant manager - Bug 1921006
+        - mozilla-group:thunderbird_releng
 - grant:
     - assume:project:releng:ci-group:team_mozillaonline
   to:


### PR DESCRIPTION
Bug 1921006 updates the thunderbird_releng LDAP group to current staff.