### PR TITLE
ci: ensure apply jobs continue even if the other fails

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: check
     environment: apply-${{matrix.environment}}
+    continue-on-error: true
     strategy:
       matrix:
         environment: ["staging", "firefoxci"]


### PR DESCRIPTION
During a recent deploy, we realized that the apply jobs will get cancelled if the other one fails.

This is bad because the apply is not atomic, so if it gets cancelled, it could leave the cluster in a bad state.