### PR TITLE
hooks: reduce max run time for code-coverage-crontrigger tasks

### DIFF
--- a/hooks/project-relman/code-coverage-crontrigger-production.yml
+++ b/hooks/project-relman/code-coverage-crontrigger-production.yml
@@ -30,7 +30,7 @@ payload:
     type: indexed-image
     namespace: code-analysis.v2.code-coverage.branch.production
     path: public/code-coverage-bot.tar.zst
-  maxRunTime: 14400
+  maxRunTime: 300
 priority: lowest
 retries: 5
 schedulerId: relman

--- a/hooks/project-relman/code-coverage-crontrigger-testing.yml
+++ b/hooks/project-relman/code-coverage-crontrigger-testing.yml
@@ -30,7 +30,7 @@ payload:
     type: indexed-image
     namespace: code-analysis.v2.code-coverage.branch.testing
     path: public/code-coverage-bot.tar.zst
-  maxRunTime: 14400
+  maxRunTime: 300
 priority: lowest
 retries: 5
 schedulerId: relman


### PR DESCRIPTION
These take about a minute, not four hours.

cc @marco-c 