### PR TITLE
Bug 1926412 - Convert mozilla/fx-desktop-qa-automation to an L3 repo

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -1254,7 +1254,7 @@ fx-desktop-qa-automation:
   trust_project: fx-desktop-qa-automation
   branches:
     - name: main
-      level: 1
+      level: 3
   features:
     github-taskgraph: true
     github-pull-request:


### PR DESCRIPTION
This will need to land at the same time as a corresponding change in `mozilla/fx-desktop-qa-automation`