### PR TITLE
fix: create mozilla-3/decision-gcp pool

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -274,6 +274,8 @@ pools:
       - pool-group: mobile-3
         chain-of-trust: trusted
       - pool-group: mozilla-1
+      - pool-group: mozilla-3
+        chain-of-trust: trusted
       - pool-group: mozillavpn-1
       - pool-group: mozillavpn-1
         suffix: "-gcp-gw"
@@ -953,6 +955,8 @@ pools:
       - pool-group: mobile-3
         chain-of-trust: trusted
       - pool-group: mozilla-1
+      - pool-group: mozilla-3
+        chain-of-trust: trusted
       - pool-group: translations-1
       - pool-group: nss-1
     config:
@@ -1009,6 +1013,8 @@ pools:
       - pool-group: app-services-3
         chain-of-trust: trusted
       - pool-group: mozilla-1
+      - pool-group: mozilla-3
+        chain-of-trust: trusted
       - pool-group: mozillavpn-1
       - pool-group: mozillavpn-3
         chain-of-trust: trusted
@@ -2182,6 +2188,8 @@ pools:
       - pool-group: comm-3
         chain-of-trust: trusted
       - pool-group: mozilla-1
+      - pool-group: mozilla-3
+        chain-of-trust: trusted
       - pool-group: mozillavpn-1
       - pool-group: mozillavpn-3
         chain-of-trust: trusted


### PR DESCRIPTION
This is needed for `mozilla/fx-desktop-qa-automation` which just transitioned to a level 3 project.

An argument could be made that they should instead get their own trust domain, but personally I feel like *all* projects should be L3. Distinguishing scopes between PRs and pushes is extremely common, even in projects that aren't particularly security sensitive.

Where I think we should draw the line for the `mozilla` trust domain, is if projects start needing scriptworkers for some reason.