### PR TITLE
fix: remove secrets:get scope for application-services developers

### DIFF
--- a/grants.yml
+++ b/grants.yml
@@ -1127,7 +1127,6 @@
     - queue:rerun-task:app-services-level-*
     - queue:get-artifact:private/docker-worker/shell.html
     - queue:scheduler-id:app-services-level-*
-    - secrets:get:project/application-services/*
   to:
     - roles:
         - mozillians-group:application-services


### PR DESCRIPTION
We want to expand the set of developers who can retrigger / cancel / use interactive tasks, etc.. But don't want everyone to be able to read the secrets.

Upon chat with app-services devs who *can* currently see the secrets, they see no need for this ability.