### PR TITLE
ci: allow scheduling tasks based on issue comments

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -5,6 +5,7 @@
 version: 1
 reporting: checks-v1
 policy:
+    allowComments: collaborators
     pullRequests: public_restricted
 tasks:
     - $let:


### PR DESCRIPTION
This will obviously fail to render if any `github-issue-comment` events are processed, but the policy needs to be live on `main` before events will get picked up at all.

So I'm landing only this change for now so I can then work on the other changes in `.taskcluster.yml` that will be needed to make it work.