### PR TITLE
chore: rename production translations repository

### DIFF
--- a/grants.yml
+++ b/grants.yml
@@ -2902,7 +2902,7 @@
   to:
     - project:
         alias:
-          - firefox-translations-training
+          - translations
         job:
           - branch:*
           - pull-request:*
@@ -2912,7 +2912,7 @@
   to:
     - project:
         alias:
-          - firefox-translations-training
+          - translations
         job:
           - branch:*
 
@@ -2921,7 +2921,7 @@
   to:
     - project:
         alias:
-          - firefox-translations-training
+          - translations
     - project:
         alias:
           - staging-firefox-translations-training

--- a/projects.yml
+++ b/projects.yml
@@ -1187,8 +1187,8 @@ code-coverage:
       policy: public
 
 # Bug 1822403: Add taskgraph support to firefox-translations-training
-firefox-translations-training:
-  repo: https://github.com/mozilla/firefox-translations-training
+translations:
+  repo: https://github.com/mozilla/translations
   repo_type: git
   branches:
     - name: main
@@ -1198,7 +1198,7 @@ firefox-translations-training:
     - name: "dev*"
       level: 1
   trust_domain: translations
-  # https://github.com/mozilla/firefox-translations-training/issues/206
+  # https://github.com/mozilla/translations/issues/206
   features:
     github-taskgraph: true
     github-pull-request:


### PR DESCRIPTION
This rename is happening in https://github.com/mozilla/firefox-translations-training/pull/914. We plan to land that change and this one around the same time rather than to support both at the same time.