### PR TITLE
Setup checkout cache for code review production hook

### DIFF
--- a/grants.yml
+++ b/grants.yml
@@ -2556,6 +2556,7 @@
 - grant:
     - secrets:get:project/relman/code-review/runtime-production
     - hooks:trigger-hook:project-relman/code-review-production
+    - docker-worker:cache:code-review-production-checkout
   to:
     - roles:
         - project:relman:code-review/runtime/production

--- a/hooks.yml
+++ b/hooks.yml
@@ -163,6 +163,7 @@ project-relman/code-review-production:
     - queue:route:notify.email.*
     - queue:scheduler-id:relman
     - secrets:get:project/relman/code-review/runtime-production
+    - docker-worker:cache:code-review-production-checkout
   template_file: hooks/project-relman/code-review-production.yml
   bindings:
     - exchange: exchange/taskcluster-queue/v1/task-completed

--- a/hooks/project-relman/code-review-production.yml
+++ b/hooks/project-relman/code-review-production.yml
@@ -16,12 +16,15 @@ payload:
     public/results:
       path: /tmp/results
       type: directory
-  cache: {}
+  cache:
+    code-review-production-checkout: '/checkouts'
   capabilities: {}
   command:
     - code-review-bot
     - '--taskcluster-secret'
     - project/relman/code-review/runtime-production
+    - '--mercurial-repository'
+    - '/checkouts'
   env:
     $merge:
       - $if: firedBy == 'triggerHook'
@@ -54,5 +57,6 @@ scopes:
   - 'secrets:get:project/relman/code-review/runtime-production'
   - 'index:insert-task:project.relman.production.code-review.*'
   - 'notify:email:*'
+  - 'docker-worker:cache:code-review-production-checkout'
 tags: {}
 workerType: bot-gcp


### PR DESCRIPTION
This is the same patch as #32 + #39 to enable a new Taskcluster cache `code-review-production-checkout` for the code review production hook (using docker-worker).