### PR TITLE
Relops 1137 - Adjust win 11 a64 test pools

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -2890,7 +2890,7 @@ pools:
               bootDiagnostics:
                 enabled: false
       capacityPerInstance: 1
-  - pool_id: gecko-t/win11-a64-24h2-tester-alpha
+  - pool_id: gecko-t/win11-a64-24h2-alpha
     description: ''
     owner: relops-azure-provisioning@mozilla.com
     email_on_error: true
@@ -2899,12 +2899,12 @@ pools:
       image: ronin_t_windows11_a64_24h2_tester_alpha
       implementation: generic-worker/worker-runner-windows
       worker-purpose: gecko-t
-      locations: [uk-south]
+      locations: [east-us-2, north-central-us, central-us]
       maxCapacity: 500
       worker-config:
         genericWorker:
           config:
-            workerType: win11-a64-24h2-tester-alpha
+            workerType: win11-a64-24h2-alpha
             provisionerId: gecko-t
             cachesDir: C:\caches
             downloadsDir: C:\downloads
@@ -2932,7 +2932,7 @@ pools:
               bootDiagnostics:
                 enabled: false
       capacityPerInstance: 1
-  - pool_id: gecko-t/win11-a64-24h2-tester
+  - pool_id: gecko-t/win11-a64-24h2
     description: ''
     owner: relops-azure-provisioning@mozilla.com
     email_on_error: true
@@ -2941,12 +2941,96 @@ pools:
       image: ronin_t_windows11_a64_24h2_tester
       implementation: generic-worker/worker-runner-windows
       worker-purpose: gecko-t
-      locations: [uk-south]
+      locations: [east-us-2, north-central-us, central-us]
       maxCapacity: 500
       worker-config:
         genericWorker:
           config:
-            workerType: win11-a64-24h2-tester
+            workerType: win11-a64-24h2
+            provisionerId: gecko-t
+            cachesDir: C:\caches
+            downloadsDir: C:\downloads
+            tasksDir: C:\
+      tags:
+        sourceScript: provisioners/windows/azure/azure-bootstrap.ps1
+        sourceBranch: cloud_windows
+        sourceRepository: ronin_puppet
+        sourceOrganisation: mozilla-platform-ops
+      spot: true
+      vmSizes:
+        - vmSize:
+          launchConfig:
+            osProfile:
+              windowsConfiguration:
+                timeZone: UTC
+                enableAutomaticUpdates: false
+            storageProfile:
+              osDisk:
+                osType: Windows
+                createOption: FromImage
+            hardwareProfile:
+              vmSize: Standard_D8ps_v5
+            diagnosticsProfile:
+              bootDiagnostics:
+                enabled: false
+      capacityPerInstance: 1
+  - pool_id: comm-t/win11-a64-24h2-alpha
+    description: ''
+    owner: relops-azure-provisioning@mozilla.com
+    email_on_error: true
+    provider_id: azure2
+    config:
+      image: ronin_t_windows11_a64_24h2_tester_alpha
+      implementation: generic-worker/worker-runner-windows
+      worker-purpose: gecko-t
+      locations: [east-us-2, north-central-us, central-us]
+      maxCapacity: 500
+      worker-config:
+        genericWorker:
+          config:
+            workerType: win11-a64-24h2-alpha
+            provisionerId: gecko-t
+            cachesDir: C:\caches
+            downloadsDir: C:\downloads
+            tasksDir: C:\
+      tags:
+        sourceScript: provisioners/windows/azure/azure-bootstrap.ps1
+        sourceBranch: cloud_windows
+        sourceRepository: ronin_puppet
+        sourceOrganisation: mozilla-platform-ops
+      spot: true
+      vmSizes:
+        - vmSize:
+          launchConfig:
+            osProfile:
+              windowsConfiguration:
+                timeZone: UTC
+                enableAutomaticUpdates: false
+            storageProfile:
+              osDisk:
+                osType: Windows
+                createOption: FromImage
+            hardwareProfile:
+              vmSize: Standard_D8ps_v5
+            diagnosticsProfile:
+              bootDiagnostics:
+                enabled: false
+      capacityPerInstance: 1
+  - pool_id: comm-t/win11-a64-24h2
+    description: ''
+    owner: relops-azure-provisioning@mozilla.com
+    email_on_error: true
+    provider_id: azure2
+    config:
+      image: ronin_t_windows11_a64_24h2_tester_alpha
+      implementation: generic-worker/worker-runner-windows
+      worker-purpose: gecko-t
+      locations: [east-us-2, north-central-us, central-us]
+      maxCapacity: 500
+      worker-config:
+        genericWorker:
+          config:
+            workerType: win11-a64-24h2-alpha
             provisionerId: gecko-t
             cachesDir: C:\caches
             downloadsDir: C:\downloads


### PR DESCRIPTION
Remove '-tester' from tester pool names. 
Change regions to avoid errors.
The `comm-t` pools with `tester` in the name will be removed after it is verified that the new pools are in use. 