### PR TITLE
Bug 1919464 - bump code-coverage/bot-gcp instance type to c2-standard-16

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -3725,7 +3725,8 @@ pools:
             - <<: *persistent-disk
               diskSizeGb: 75
             - *scratch-disk
-          machine_type: c2-standard-8
+            - *scratch-disk
+          machine_type: c2-standard-16
       worker-config:
         shutdown:
           afterIdleSeconds: 900


### PR DESCRIPTION
It looks like we're still OOMing on c2-standard-8.

cc @marco-c 