### PR TITLE
Only use Taskcluster staging instance for pull request comments

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -10,69 +10,8 @@ policy:
 tasks:
     - $let:
           trustDomain: ci
-          ownerEmail:
-              $switch:
-                  'tasks_for == "github-push"': '${event.pusher.email}'
-                  'tasks_for == "github-release"': 'release+taskgraph-ci@mozilla.com'
-                  'tasks_for[:19] == "github-pull-request"': '${event.pull_request.user.login}@users.noreply.github.com'
-                  'tasks_for in ["cron", "action", "pr-action"]': '${tasks_for}@noreply.mozilla.org'
-          baseRepoUrl:
-              $switch:
-                  'tasks_for[:19] == "github-pull-request"': '${event.pull_request.base.repo.html_url}'
-                  'tasks_for in ["cron", "action"]': '${repository.url}'
-                  'tasks_for == "pr-action"': '${repository.base_url}'
-                  $default: '${event.repository.html_url}'
-          repoUrl:
-              $switch:
-                  'tasks_for[:19] == "github-pull-request"': '${event.pull_request.head.repo.html_url}'
-                  'tasks_for in ["cron", "action", "pr-action"]': '${repository.url}'
-                  $default: '${event.repository.html_url}'
-          project:
-              $switch:
-                  'tasks_for in ["github-push", "github-release"]': '${event.repository.name}'
-                  'tasks_for[:19] == "github-pull-request"': '${event.pull_request.head.repo.name}'
-                  'tasks_for in ["cron", "action", "pr-action"]': '${repository.project}'
-          head_branch:
-              $switch:
-                  'tasks_for[:19] == "github-pull-request"': ${event.pull_request.head.ref}
-                  'tasks_for == "github-push"': ${event.ref}
-                  'tasks_for == "github-release"': '${event.release.target_commitish}'
-                  'tasks_for in ["cron", "action", "pr-action"]': '${push.branch}'
-          base_ref:
-              $switch:
-                  'tasks_for[:19] == "github-pull-request"': ${event.pull_request.base.ref}
-                  # event.base_ref is barely documented[1]. Testing showed it's only
-                  # defined when creating a new branch. It's null when pushing to an
-                  # existing branch
-                  #
-                  # [1] https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#push
-                  'tasks_for == "github-push" && event.base_ref': ${event.base_ref}
-                  'tasks_for == "github-push" && !(event.base_ref)': ${event.ref}
-                  'tasks_for == "github-release"': ''
-                  'tasks_for in ["cron", "action"]': '${push.branch}'
-                  'tasks_for == "pr-action"': '${push.base_branch}'
-          head_ref:
-              $switch:
-                  'tasks_for[:19] == "github-pull-request"': ${event.pull_request.head.ref}
-                  'tasks_for == "github-push"': ${event.ref}
-                  'tasks_for in ["cron", "action", "pr-action"]': '${push.branch}'
-                  'tasks_for == "github-release"': ${event.release.tag_name}
-          base_sha:
-              $switch:
-                  'tasks_for == "github-push"': '${event.before}'
-                  'tasks_for == "github-release"': '${event.release.target_commitish}'
-                  'tasks_for[:19] == "github-pull-request"': '${event.pull_request.base.sha}'
-                  'tasks_for in ["cron", "action", "pr-action"]': '${push.revision}'
-          head_sha:
-              $switch:
-                  'tasks_for == "github-push"': '${event.after}'
-                  'tasks_for[:19] == "github-pull-request"': '${event.pull_request.head.sha}'
-                  'tasks_for in ["cron", "action", "pr-action"]': '${push.revision}'
-                  'tasks_for == "github-release"': '${event.release.tag_name}'
-          ownTaskId:
-              $switch:
-                  '"github" in tasks_for': {$eval: as_slugid("decision_task")}
-                  'tasks_for in ["cron", "action", "pr-action"]': '${ownTaskId}'
+          isPullRequest:
+              $eval: 'tasks_for[:19] == "github-pull-request" || tasks_for == "github-issue-comment"'
           pullRequestAction:
               $switch:
                   'tasks_for[:19] == "github-pull-request"': ${event.action}
@@ -81,210 +20,285 @@ tasks:
               $if: 'tasks_for == "github-release"'
               then: ${event.action}
               else: 'UNDEFINED'
-          isPullRequest:
-              $eval: 'tasks_for[:19] == "github-pull-request"'
+          issueCommentAction:
+              $switch:
+                  'tasks_for == "github-issue-comment"': ${event.action}
+                  $default: 'UNDEFINED'
+          ownTaskId:
+              $switch:
+                  '"github" in tasks_for': {$eval: as_slugid("decision_task")}
+                  'tasks_for in ["cron", "action", "pr-action"]': '${ownTaskId}'
       in:
           $let:
-              level:
-                  $if: 'tasks_for in ["github-release", "github-push", "cron", "action"] && repoUrl == "https://github.com/mozilla-releng/fxci-config"'
-                  then: 3
-                  else: 1
-              short_head_ref:
-                  $if: 'head_ref[:10] == "refs/tags/"'
-                  then: {$eval: 'head_ref[10:]'}
-                  else:
-                      $if: 'head_ref[:11] == "refs/heads/"'
-                      then: {$eval: 'head_ref[11:]'}
-                      else: ${head_ref}
+              ownerEmail:
+                  $switch:
+                      'tasks_for == "github-push"': '${event.pusher.email}'
+                      'tasks_for == "github-release"': 'release+taskgraph-ci@mozilla.com'
+                      'isPullRequest': '${event.pull_request.user.login}@users.noreply.github.com'
+                      'tasks_for in ["cron", "action", "pr-action"]': '${tasks_for}@noreply.mozilla.org'
+              baseRepoUrl:
+                  $switch:
+                      'isPullRequest': '${event.pull_request.base.repo.html_url}'
+                      'tasks_for in ["cron", "action"]': '${repository.url}'
+                      'tasks_for == "pr-action"': '${repository.base_url}'
+                      $default: '${event.repository.html_url}'
+              repoUrl:
+                  $switch:
+                      'isPullRequest': '${event.pull_request.head.repo.html_url}'
+                      'tasks_for in ["cron", "action", "pr-action"]': '${repository.url}'
+                      $default: '${event.repository.html_url}'
+              project:
+                  $switch:
+                      'tasks_for in ["github-push", "github-release"]': '${event.repository.name}'
+                      'isPullRequest': '${event.pull_request.head.repo.name}'
+                      'tasks_for in ["cron", "action", "pr-action"]': '${repository.project}'
+              head_branch:
+                  $switch:
+                      'isPullRequest': ${event.pull_request.head.ref}
+                      'tasks_for == "github-push"': ${event.ref}
+                      'tasks_for == "github-release"': '${event.release.target_commitish}'
+                      'tasks_for in ["cron", "action", "pr-action"]': '${push.branch}'
+              base_ref:
+                  $switch:
+                      'isPullRequest': ${event.pull_request.base.ref}
+                      # event.base_ref is barely documented[1]. Testing showed it's only
+                      # defined when creating a new branch. It's null when pushing to an
+                      # existing branch
+                      #
+                      # [1] https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#push
+                      'tasks_for == "github-push" && event.base_ref': ${event.base_ref}
+                      'tasks_for == "github-push" && !(event.base_ref)': ${event.ref}
+                      'tasks_for == "github-release"': ''
+                      'tasks_for in ["cron", "action"]': '${push.branch}'
+                      'tasks_for == "pr-action"': '${push.base_branch}'
+              head_ref:
+                  $switch:
+                      'isPullRequest': ${event.pull_request.head.ref}
+                      'tasks_for == "github-push"': ${event.ref}
+                      'tasks_for in ["cron", "action", "pr-action"]': '${push.branch}'
+                      'tasks_for == "github-release"': ${event.release.tag_name}
+              base_sha:
+                  $switch:
+                      'tasks_for == "github-push"': '${event.before}'
+                      'tasks_for == "github-release"': '${event.release.target_commitish}'
+                      'isPullRequest': '${event.pull_request.base.sha}'
+                      'tasks_for in ["cron", "action", "pr-action"]': '${push.revision}'
+              head_sha:
+                  $switch:
+                      'tasks_for == "github-push"': '${event.after}'
+                      'isPullRequest': '${event.pull_request.head.sha}'
+                      'tasks_for in ["cron", "action", "pr-action"]': '${push.revision}'
+                      'tasks_for == "github-release"': '${event.release.tag_name}'
           in:
-              $if: >
-                tasks_for in ["action", "pr-action", "cron"]
-                || (tasks_for == "github-release" && releaseAction == "published")
-                || (tasks_for == "github-push" && short_head_ref == "main")
-                || (isPullRequest && pullRequestAction in ["opened", "reopened", "synchronize"])
-              then:
-                  taskId: {$if: 'tasks_for != "action"', then: '${ownTaskId}'}
-                  taskGroupId:
-                      $if: 'tasks_for == "action"'
-                      then:
-                          '${action.taskGroupId}'
-                      else:
-                          '${ownTaskId}'  # same as taskId; this is how automation identifies a decision task
-                  schedulerId: '${trustDomain}-level-${level}'
-
-                  created: {$fromNow: ''}
-                  deadline: {$fromNow: '1 day'}
-                  expires: {$fromNow: '1 year 1 second'}  # 1 second so artifacts expire first
-                  metadata:
-                      $merge:
-                          - owner: "${ownerEmail}"
-                            source: "${repoUrl}/raw/${head_sha}/.taskcluster.yml"
-                          - $switch:
-                                'tasks_for in ["github-push", "github-release"] || isPullRequest':
-                                    name: "Decision Task (${tasks_for[7:]})"  # strip out "github-" from tasks_for
-                                    description: 'The task that creates all of the other tasks in the task graph'
-                                'tasks_for == "action"':
-                                    name: "Action: ${action.title}"
-                                    description: |
-                                        ${action.description}
-
-                                        Action triggered by clientID `${clientId}`
-                                'tasks_for == "pr-action"':
-                                    name: "PR action: ${action.title}"
-                                    description: |
-                                        ${action.description}
-
-                                        PR action triggered by clientID `${clientId}`
-                                $default:
-                                    name: "Decision Task for cron job ${cron.job_name}"
-                                    description: 'Created by a [cron task](https://firefox-ci-tc.services.mozilla.com/tasks/${cron.task_id})'
-                  provisionerId: "${trustDomain}-${level}"
-                  workerType: "decision-gcp"
-                  tags:
+              $let:
+                  level:
+                      $if: 'tasks_for in ["github-release", "github-push", "cron", "action"] && repoUrl == "https://github.com/mozilla-releng/fxci-config"'
+                      then: 3
+                      else: 1
+                  short_head_ref:
                       $switch:
-                          'tasks_for == "github-push" || isPullRequest':
-                              createdForUser: "${ownerEmail}"
-                              kind: decision-task
-                          'tasks_for == "action" || tasks_for == "pr-action"':
-                              createdForUser: '${ownerEmail}'
-                              kind: 'action-callback'
-                          'tasks_for == "cron"':
-                              kind: cron-task
-                  routes:
-                      $flatten:
-                          - checks
-                          - $switch:
-                                'tasks_for == "github-push"':
-                                    - "index.${trustDomain}.v2.${project}.latest.taskgraph.decision"
-                                    - "index.${trustDomain}.v2.${project}.revision.${head_sha}.taskgraph.decision"
-                                'tasks_for == "action"':
-                                    - "index.${trustDomain}.v2.${project}.revision.${head_sha}.taskgraph.actions.${ownTaskId}"
-                                'tasks_for == "cron"':
-                                    - "index.${trustDomain}.v2.${project}.latest.taskgraph.decision-${cron.job_name}"
-                                    - "index.${trustDomain}.v2.${project}.revision.${head_sha}.taskgraph.decision-${cron.job_name}"
-                                    # list each cron task on this revision, so actions can find them
-                                    - 'index.${trustDomain}.v2.${project}.revision.${head_sha}.cron.${ownTaskId}'
-                                $default: []
-                  scopes:
-                      $switch:
-                          'tasks_for == "github-push"':
-                              - 'assume:repo:${repoUrl[8:]}:branch:${short_head_ref}'
-                          'tasks_for == "github-release"':
-                              - 'assume:repo:${repoUrl[8:]}:release:${releaseAction}'
-                          'isPullRequest':
-                              - 'assume:repo:github.com/${event.pull_request.base.repo.full_name}:${tasks_for[7:]}'
-                          'tasks_for == "action"':
-                              - 'assume:repo:${repoUrl[8:]}:action:${action.action_perm}'
-                          'tasks_for == "pr-action"':
-                              - 'assume:repo:${baseRepoUrl[8:]}:pr-action:${action.action_perm}'
-                          $default:
-                              - 'assume:repo:${repoUrl[8:]}:cron:${cron.job_name}'
-                  dependencies: []
-                  requires: all-completed
-                  priority:
-                      # Most times, there is plenty of worker capacity so everything runs
-                      # quickly, but sometimes a storm of action tasks lands.  Then we
-                      # want, from highest to lowest:
-                      # - cron tasks (time-sensitive) (low)
-                      # - decision tasks (minimize user-visible delay) (very-low)
-                      # - action tasks (avoid interfering with the other two) (lowest)
-                      # SCM levels all use different workerTypes, so there is no need for priority
-                      # between levels; "low" is the highest priority available at all levels, and
-                      # nothing runs at any higher priority on these workerTypes.
-                      $if: "tasks_for == 'cron'"
-                      then: low
-                      else:
-                          $if: 'tasks_for == "github-push" || isPullRequest'
-                          then: very-low
-                          else: lowest  # tasks_for == 'action'
-                  retries: 5
-                  payload:
-                      env:
-                          # run-task uses these to check out the source; the inputs
-                          # to `taskgraph decision` are all on the command line.
+                          'head_ref[:10] == "refs/tags/"': '${head_ref[10:]}'
+                          'head_ref[:11] == "refs/heads/"': '${head_ref[11:]}'
+                          $default: '${head_ref}'
+              in:
+                  $if: >
+                    tasks_for in ["action", "pr-action", "cron"]
+                    || (tasks_for == "github-release" && releaseAction == "published")
+                    || (tasks_for == "github-push" && short_head_ref == "main")
+                    || (isPullRequest && pullRequestAction in ["opened", "reopened", "synchronize"])
+                    || (isPullRequest && issueCommentAction in ["created", "edited"])
+                  then:
+                      taskId: {$if: 'tasks_for != "action"', then: '${ownTaskId}'}
+                      taskGroupId:
+                          $if: 'tasks_for == "action"'
+                          then:
+                              '${action.taskGroupId}'
+                          else:
+                              '${ownTaskId}'  # same as taskId; this is how automation identifies a decision task
+                      schedulerId: '${trustDomain}-level-${level}'
+
+                      created: {$fromNow: ''}
+                      deadline: {$fromNow: '1 day'}
+                      expires: {$fromNow: '1 year 1 second'}  # 1 second so artifacts expire first
+                      metadata:
                           $merge:
-                              - FXCI_BASE_REPOSITORY: '${repoUrl}'
-                                FXCI_BASE_REF: '${base_ref}'
-                                FXCI_BASE_REV: '${base_sha}'
-                                FXCI_HEAD_REPOSITORY: '${repoUrl}'
-                                FXCI_HEAD_REF: '${head_ref}'
-                                FXCI_HEAD_REV: '${head_sha}'
-                                FXCI_REPOSITORY_TYPE: git
-                                REPOSITORIES: {$json: {fxci: "Firefox-CI Config"}}
+                              - owner: "${ownerEmail}"
+                                source: "${repoUrl}/raw/${head_sha}/.taskcluster.yml"
+                              - $switch:
+                                    'tasks_for in ["github-push", "github-release"] || isPullRequest':
+                                        name: "Decision Task (${tasks_for[7:]})"  # strip out "github-" from tasks_for
+                                        description: 'The task that creates all of the other tasks in the task graph'
+                                    'tasks_for == "action"':
+                                        name: "Action: ${action.title}"
+                                        description: |
+                                            ${action.description}
+
+                                            Action triggered by clientID `${clientId}`
+                                    'tasks_for == "pr-action"':
+                                        name: "PR action: ${action.title}"
+                                        description: |
+                                            ${action.description}
+
+                                            PR action triggered by clientID `${clientId}`
+                                    $default:
+                                        name: "Decision Task for cron job ${cron.job_name}"
+                                        description: 'Created by a [cron task](https://firefox-ci-tc.services.mozilla.com/tasks/${cron.task_id})'
+                      provisionerId: "${trustDomain}-${level}"
+                      workerType: "decision-gcp"
+                      tags:
+                          $switch:
+                              'tasks_for == "github-push" || isPullRequest':
+                                  createdForUser: "${ownerEmail}"
+                                  kind: decision-task
+                              'tasks_for == "action" || tasks_for == "pr-action"':
+                                  createdForUser: '${ownerEmail}'
+                                  kind: 'action-callback'
+                              'tasks_for == "cron"':
+                                  kind: cron-task
+                      routes:
+                          $flatten:
+                              - checks
+                              - $switch:
+                                    'tasks_for == "github-push"':
+                                        - "index.${trustDomain}.v2.${project}.latest.taskgraph.decision"
+                                        - "index.${trustDomain}.v2.${project}.revision.${head_sha}.taskgraph.decision"
+                                    'tasks_for == "action"':
+                                        - "index.${trustDomain}.v2.${project}.revision.${head_sha}.taskgraph.actions.${ownTaskId}"
+                                    'tasks_for == "cron"':
+                                        - "index.${trustDomain}.v2.${project}.latest.taskgraph.decision-${cron.job_name}"
+                                        - "index.${trustDomain}.v2.${project}.revision.${head_sha}.taskgraph.decision-${cron.job_name}"
+                                        # list each cron task on this revision, so actions can find them
+                                        - 'index.${trustDomain}.v2.${project}.revision.${head_sha}.cron.${ownTaskId}'
+                                    $default: []
+                      scopes:
+                          $switch:
+                              'tasks_for == "github-push"':
+                                  - 'assume:repo:${repoUrl[8:]}:branch:${short_head_ref}'
+                              'tasks_for == "github-release"':
+                                  - 'assume:repo:${repoUrl[8:]}:release:${releaseAction}'
+                              'tasks_for[:19] == "github-pull-request"':
+                                  - 'assume:repo:github.com/${event.pull_request.base.repo.full_name}:${tasks_for[7:]}'
+                              'tasks_for == "github-issue-comment"':
+                                  - 'assume:repo:github.com/${event.pull_request.base.repo.full_name}:pull-request'
+                              'tasks_for == "action"':
+                                  - 'assume:repo:${repoUrl[8:]}:action:${action.action_perm}'
+                              'tasks_for == "pr-action"':
+                                  - 'assume:repo:${baseRepoUrl[8:]}:pr-action:${action.action_perm}'
+                              $default:
+                                  - 'assume:repo:${repoUrl[8:]}:cron:${cron.job_name}'
+                      dependencies: []
+                      requires: all-completed
+                      priority:
+                          # Most times, there is plenty of worker capacity so everything runs
+                          # quickly, but sometimes a storm of action tasks lands.  Then we
+                          # want, from highest to lowest:
+                          # - cron tasks (time-sensitive) (low)
+                          # - decision tasks (minimize user-visible delay) (very-low)
+                          # - action tasks (avoid interfering with the other two) (lowest)
+                          # SCM levels all use different workerTypes, so there is no need for priority
+                          # between levels; "low" is the highest priority available at all levels, and
+                          # nothing runs at any higher priority on these workerTypes.
+                          $if: "tasks_for == 'cron'"
+                          then: low
+                          else:
+                              $if: 'tasks_for == "github-push" || isPullRequest'
+                              then: very-low
+                              else: lowest  # tasks_for == 'action'
+                      retries: 5
+                      payload:
+                          env:
+                              # run-task uses these to check out the source; the inputs
+                              # to `taskgraph decision` are all on the command line.
+                              $merge:
+                                  - FXCI_BASE_REPOSITORY: '${repoUrl}'
+                                    FXCI_BASE_REF: '${base_ref}'
+                                    FXCI_BASE_REV: '${base_sha}'
+                                    FXCI_HEAD_REPOSITORY: '${repoUrl}'
+                                    FXCI_HEAD_REF: '${head_ref}'
+                                    FXCI_HEAD_REV: '${head_sha}'
+                                    FXCI_REPOSITORY_TYPE: git
+                                    REPOSITORIES: {$json: {fxci: "Firefox-CI Config"}}
+                                  - $if: 'tasks_for == "action"'
+                                    then:
+                                        ACTION_TASK_GROUP_ID: '${action.taskGroupId}'  # taskGroupId of the target task
+                                        ACTION_TASK_ID: {$json: {$eval: 'taskId'}}  # taskId of the target task (JSON-encoded)
+                                        ACTION_INPUT: {$json: {$eval: 'input'}}
+                                        ACTION_CALLBACK: '${action.cb_name}'
+                          cache:
+                              ${trustDomain}-level-${level}-checkouts-sparse-v1: /builds/worker/checkouts
+                          features:
+                              taskclusterProxy: true
+                              chainOfTrust: true
+                          image:
+                              mozillareleases/taskgraph:decision-v7.3.1@sha256:1d1364c01c13002a13863f0ef27dd7331ad1c7fe92bbb8b0b4019dc5a821461c
+                          maxRunTime: 1800
+                          command:
+                              $flatten:
+                                  - run-task
+                                  - '--fxci-checkout=/builds/worker/checkouts/src'
+                                  - '--task-cwd=/builds/worker/checkouts/src'
+                                  - '--'
+                                  - bash
+                                  - -cx
+                                  - $let:
+                                        extraArgs:
+                                            # Can't use $switch statement here, see https://github.com/json-e/json-e/issues/541
+                                            $if: 'tasks_for == "cron"'
+                                            then: '${cron.quoted_args}'
+                                            else:
+                                                $if: 'tasks_for == "github-issue-comment"'
+                                                then: '--target-tasks-method=${event.taskcluster_comment}'
+                                                else: ''
+                                    in:
+                                        $if: 'tasks_for == "action"'
+                                        then: >
+                                            cd /builds/worker/checkouts/src &&
+                                            ln -s /builds/worker/artifacts artifacts &&
+                                            taskgraph action-callback
+                                        else: >
+                                            ln -s /builds/worker/artifacts artifacts &&
+                                            taskgraph decision
+                                            --pushlog-id='0'
+                                            --pushdate='0'
+                                            --project='${project}'
+                                            --owner='${ownerEmail}'
+                                            --level='${level}'
+                                            --repository-type=git
+                                            --tasks-for='${tasks_for}'
+                                            --base-repository='${baseRepoUrl}'
+                                            --base-ref='${base_ref}'
+                                            --base-rev='${base_sha}'
+                                            --head-repository='${repoUrl}'
+                                            --head-ref='${head_ref}'
+                                            --head-rev='${head_sha}'
+                                            $${TRY_TASK_CONFIG_FILE+--try-task-config-file="$${TRY_TASK_CONFIG_FILE}"}
+                                            ${extraArgs}
+                          artifacts:
+                              'public':
+                                  type: 'directory'
+                                  path: '/builds/worker/artifacts'
+                                  expires: {$fromNow: '1 year'}
+                              'public/docker-contexts':
+                                  type: 'directory'
+                                  path: '/builds/worker/checkouts/src/docker-contexts'
+                                  # This needs to be at least the deadline of the
+                                  # decision task + the docker-image task deadlines.
+                                  # It is set to a week to allow for some time for
+                                  # debugging, but they are not useful long-term.
+                                  expires: {$fromNow: '7 day'}
+
+                      extra:
+                          $merge:
                               - $if: 'tasks_for == "action"'
                                 then:
-                                    ACTION_TASK_GROUP_ID: '${action.taskGroupId}'  # taskGroupId of the target task
-                                    ACTION_TASK_ID: {$json: {$eval: 'taskId'}}  # taskId of the target task (JSON-encoded)
-                                    ACTION_INPUT: {$json: {$eval: 'input'}}
-                                    ACTION_CALLBACK: '${action.cb_name}'
-                      cache:
-                          ${trustDomain}-level-${level}-checkouts-sparse-v1: /builds/worker/checkouts
-                      features:
-                          taskclusterProxy: true
-                          chainOfTrust: true
-                      image:
-                          mozillareleases/taskgraph:decision-v7.3.1@sha256:1d1364c01c13002a13863f0ef27dd7331ad1c7fe92bbb8b0b4019dc5a821461c
-                      maxRunTime: 1800
-                      command:
-                          $flatten:
-                              - run-task
-                              - '--fxci-checkout=/builds/worker/checkouts/src'
-                              - '--task-cwd=/builds/worker/checkouts/src'
-                              - '--'
-                              - bash
-                              - -cx
-                              - $let:
-                                    extraArgs: {$if: 'tasks_for == "cron"', then: '${cron.quoted_args}', else: ''}
-                                in:
-                                    $if: 'tasks_for == "action"'
-                                    then: >
-                                        cd /builds/worker/checkouts/src &&
-                                        ln -s /builds/worker/artifacts artifacts &&
-                                        taskgraph action-callback
-                                    else: >
-                                        ln -s /builds/worker/artifacts artifacts &&
-                                        taskgraph decision
-                                        --pushlog-id='0'
-                                        --pushdate='0'
-                                        --project='${project}'
-                                        --owner='${ownerEmail}'
-                                        --level='${level}'
-                                        --repository-type=git
-                                        --tasks-for='${tasks_for}'
-                                        --base-repository='${baseRepoUrl}'
-                                        --base-ref='${base_ref}'
-                                        --base-rev='${base_sha}'
-                                        --head-repository='${repoUrl}'
-                                        --head-ref='${head_ref}'
-                                        --head-rev='${head_sha}'
-                                        $${TRY_TASK_CONFIG_FILE+--try-task-config-file="$${TRY_TASK_CONFIG_FILE}"}
-                                        ${extraArgs}
-                      artifacts:
-                          'public':
-                              type: 'directory'
-                              path: '/builds/worker/artifacts'
-                              expires: {$fromNow: '1 year'}
-                          'public/docker-contexts':
-                              type: 'directory'
-                              path: '/builds/worker/checkouts/src/docker-contexts'
-                              # This needs to be at least the deadline of the
-                              # decision task + the docker-image task deadlines.
-                              # It is set to a week to allow for some time for
-                              # debugging, but they are not useful long-term.
-                              expires: {$fromNow: '7 day'}
-
-                  extra:
-                      $merge:
-                          - $if: 'tasks_for == "action"'
-                            then:
-                                parent: '${action.taskGroupId}'
-                                action:
-                                    name: '${action.name}'
-                                    context:
-                                        taskGroupId: '${action.taskGroupId}'
-                                        taskId: {$eval: 'taskId'}
-                                        input: {$eval: 'input'}
-                          - $if: 'tasks_for == "cron"'
-                            then:
-                                cron: {$json: {$eval: 'cron'}}
-                          - tasks_for: '${tasks_for}'
+                                    parent: '${action.taskGroupId}'
+                                    action:
+                                        name: '${action.name}'
+                                        context:
+                                            taskGroupId: '${action.taskGroupId}'
+                                            taskId: {$eval: 'taskId'}
+                                            input: {$eval: 'input'}
+                              - $if: 'tasks_for == "cron"'
+                                then:
+                                    cron: {$json: {$eval: 'cron'}}
+                              - tasks_for: '${tasks_for}'

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -10,6 +10,10 @@ policy:
 tasks:
     - $let:
           trustDomain: ci
+          taskclusterInstance:
+              $switch:
+                  'taskcluster_root_url == "https://firefox-ci-tc.services.mozilla.com"': "firefoxci"
+                  'taskcluster_root_url == "https://stage.taskcluster.nonprod.cloudops.mozgcp.net"': "staging"
           isPullRequest:
               $eval: 'tasks_for[:19] == "github-pull-request" || tasks_for == "github-issue-comment"'
           pullRequestAction:
@@ -102,11 +106,13 @@ tasks:
                           $default: '${head_ref}'
               in:
                   $if: >
-                    tasks_for in ["action", "pr-action", "cron"]
-                    || (tasks_for == "github-release" && releaseAction == "published")
-                    || (tasks_for == "github-push" && short_head_ref == "main")
-                    || (isPullRequest && pullRequestAction in ["opened", "reopened", "synchronize"])
-                    || (isPullRequest && issueCommentAction in ["created", "edited"])
+                    (taskclusterInstance == "firefoxci"
+                     && (tasks_for in ["action", "pr-action", "cron"]
+                         || (tasks_for == "github-release" && releaseAction == "published")
+                         || (tasks_for == "github-push" && short_head_ref == "main")
+                         || (isPullRequest && pullRequestAction in ["opened", "reopened", "synchronize"])))
+                    || (taskclusterInstance == "staging"
+                        && (isPullRequest && issueCommentAction in ["created", "edited"]))
                   then:
                       taskId: {$if: 'tasks_for != "action"', then: '${ownTaskId}'}
                       taskGroupId:

--- a/grants.yml
+++ b/grants.yml
@@ -1198,13 +1198,20 @@
     # We grant a client for Taskcluster stage so `fxci-config` PRs can
     # deploy themselves there for testing.
     - secrets:get:project/releng/fxci-config/taskcluster-stage-client
-    # We grant ability to create `gecko-t` tasks so we can validate image
-    # changes before they land.
+  to:
+    - project:
+        alias: fxci-config
+        job: [pull-request:trusted]
+
+- grant:
+    # We grant ability to create `gecko-t` tasks in the staging instance so we
+    # can validate image changes before they land.
     - queue:create-task:{priority}:gecko-t/*
   to:
     - project:
         alias: fxci-config
         job: [pull-request:trusted]
+  environment: staging
 
 # - k8s-autoscale roles
 - grant:


### PR DESCRIPTION
This is needed to prevent us from running two Decision tasks on every push / pull-request.