### PR TITLE
cleanup: remove unused translations image and pool

### DIFF
--- a/worker-images.yml
+++ b/worker-images.yml
@@ -54,9 +54,6 @@ monopacker-docker-worker-2024-06-14-relops993:
 # monopacker generic-worker vm images (chronologically ordered)
 monopacker-translations-worker:
   fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-translations-gcp-googlecompute-2024-04-22t18-22-42z
-# temporary test image that includes https://github.com/mozilla-platform-ops/monopacker/pull/149
-monopacker-translations-worker-issue149:
-  fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-translations-gcp-googlecompute-2024-10-11t18-26-57z
 monopacker-ubuntu-2204-wayland:
   fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-gui-googlecompute-2024-08-22t22-48-09z
   fxci-level3-gcp: projects/fxci-production-level3-workers/global/images/gw-fxci-gcp-l3-gui-googlecompute-2024-09-18t05-46-31z

--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -1712,37 +1712,6 @@ pools:
             - <<: *persistent-disk
               diskSizeGb: 60
           machine_type: c2-standard-8
-  - pool_id: '{pool-group}/b-linux-v100-gpu-issue149'
-    description: Worker for machine learning and other high GPU tasks
-    owner: release+tc-workers@mozilla.com
-    variants:
-      - pool-group: translations-1
-    email_on_error: true
-    provider_id:
-      by-chain-of-trust:
-        trusted: fxci-level3-gcp
-        default: fxci-level1-gcp
-    config:
-      worker-config:
-        genericWorker:
-          config:
-            # 2592000s is 30 days.
-            maxTaskRunTime: 2592000
-            enableInteractive: true
-      minCapacity: 0
-      maxCapacity: 200
-      implementation: generic-worker/worker-runner-linux
-      regions: [us-central1, us-west1, us-east1]
-      image: monopacker-translations-worker-issue149
-      instance_types:
-        - minCpuPlatform: Intel Skylake
-          disks:
-            - <<: *persistent-disk
-              diskSizeGb: 75
-          machine_type: n1-highmem-8
-          guestAccelerators:
-            - acceleratorCount: 1
-              acceleratorType: nvidia-tesla-v100
   - pool_id: '{pool-group}/b-linux-v100-gpu'
     description: Worker for machine learning and other high GPU tasks
     owner: release+tc-workers@mozilla.com


### PR DESCRIPTION
I'm not actively debugging dns stuff for translations; let's remove these for now to avoid confusion.