### PR TITLE
use new ubuntu 24.04 headless images for d2g translations images

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -398,11 +398,14 @@ pools:
             # 2592000s is 30 days.
             maxTaskRunTime: 2592000
             enableInteractive: true
+            enableD2G: true
+            containerEngine: docker
+            ed25519SigningKeyLocation: '/etc/generic-worker/ed25519_key'
       minCapacity: 0
       maxCapacity: 1000
       implementation: generic-worker/worker-runner-linux-multi
       regions: [us-central1, us-west1]
-      image: monopacker-ubuntu-2204-wayland
+      image: ubuntu-2404-headless-alpha
       instance_types:
         - minCpuPlatform: Intel Cascadelake
           disks:
@@ -426,11 +429,14 @@ pools:
             # 2592000s is 30 days.
             maxTaskRunTime: 2592000
             enableInteractive: true
+            enableD2G: true
+            containerEngine: docker
+            ed25519SigningKeyLocation: '/etc/generic-worker/ed25519_key'
       minCapacity: 0
       maxCapacity: 1000
       implementation: generic-worker/worker-runner-linux-multi
       regions: [us-central1, us-west1]
-      image: monopacker-ubuntu-2204-wayland
+      image: ubuntu-2404-headless-alpha
       instance_types:
         - minCpuPlatform: Intel Cascadelake
           disks:
@@ -454,11 +460,14 @@ pools:
             # 2592000s is 30 days.
             maxTaskRunTime: 2592000
             enableInteractive: true
+            enableD2G: true
+            containerEngine: docker
+            ed25519SigningKeyLocation: '/etc/generic-worker/ed25519_key'
       minCapacity: 0
       maxCapacity: 1000
       implementation: generic-worker/worker-runner-linux-multi
       regions: [us-central1, us-west1]
-      image: monopacker-ubuntu-2204-wayland
+      image: ubuntu-2404-headless-alpha
       instance_types:
         - minCpuPlatform: Intel Cascadelake
           disks:
@@ -483,11 +492,14 @@ pools:
             # 2592000s is 30 days.
             maxTaskRunTime: 2592000
             enableInteractive: true
+            enableD2G: true
+            containerEngine: docker
+            ed25519SigningKeyLocation: '/etc/generic-worker/ed25519_key'
       minCapacity: 0
       maxCapacity: 1000
       implementation: generic-worker/worker-runner-linux-multi
       regions: [us-central1, us-west1]
-      image: monopacker-ubuntu-2204-wayland
+      image: ubuntu-2404-headless-alpha
       instance_types:
         - minCpuPlatform: Intel Cascadelake
           disks:
@@ -539,11 +551,14 @@ pools:
             # 2592000s is 30 days.
             maxTaskRunTime: 2592000
             enableInteractive: true
+            enableD2G: true
+            containerEngine: docker
+            ed25519SigningKeyLocation: '/etc/generic-worker/ed25519_key'
       minCapacity: 0
       maxCapacity: 1000
       implementation: generic-worker/worker-runner-linux-multi
       regions: [us-central1, us-west1]
-      image: monopacker-ubuntu-2204-wayland
+      image: ubuntu-2404-headless-alpha
       instance_types:
         - minCpuPlatform: Intel Cascadelake
           disks:
@@ -567,11 +582,14 @@ pools:
             # 2592000s is 30 days.
             maxTaskRunTime: 2592000
             enableInteractive: true
+            enableD2G: true
+            containerEngine: docker
+            ed25519SigningKeyLocation: '/etc/generic-worker/ed25519_key'
       minCapacity: 0
       maxCapacity: 16
       implementation: generic-worker/worker-runner-linux-multi
       regions: [us-central1, us-west1]
-      image: monopacker-ubuntu-2204-wayland
+      image: ubuntu-2404-headless-alpha
       instance_types:
         - minCpuPlatform: Intel Cascadelake
           disks:
@@ -596,11 +614,14 @@ pools:
             # 2592000s is 30 days.
             maxTaskRunTime: 2592000
             enableInteractive: true
+            enableD2G: true
+            containerEngine: docker
+            ed25519SigningKeyLocation: '/etc/generic-worker/ed25519_key'
       minCapacity: 0
       maxCapacity: 1000
       implementation: generic-worker/worker-runner-linux-multi
       regions: [us-central1, us-west1]
-      image: monopacker-ubuntu-2204-wayland
+      image: ubuntu-2404-headless-alpha
       instance_types:
         - minCpuPlatform: Intel Cascadelake
           disks:
@@ -624,11 +645,14 @@ pools:
             # 2592000s is 30 days.
             maxTaskRunTime: 2592000
             enableInteractive: true
+            enableD2G: true
+            containerEngine: docker
+            ed25519SigningKeyLocation: '/etc/generic-worker/ed25519_key'
       minCapacity: 0
       maxCapacity: 8
       implementation: generic-worker/worker-runner-linux-multi
       regions: [us-central1, us-west1]
-      image: monopacker-ubuntu-2204-wayland
+      image: ubuntu-2404-headless-alpha
       instance_types:
         - minCpuPlatform: Intel Cascadelake
           disks:
@@ -1943,6 +1967,81 @@ pools:
           disks:
             - <<: *persistent-disk
               diskSizeGb: 2048
+          # 40 CPUs, 256GB RAM
+          machine_type: n1-custom-40-262144
+          guestAccelerators:
+            - acceleratorCount: 4
+              acceleratorType: nvidia-tesla-v100
+  - pool_id: '{pool-group}/b-linux-v100-gpu-d2g-4'
+    description: Worker for machine learning and other high GPU tasks
+    owner: release+tc-workers@mozilla.com
+    variants:
+      - pool-group: translations-1
+    email_on_error: true
+    provider_id:
+      by-chain-of-trust:
+        trusted: fxci-level3-gcp
+        default: fxci-level1-gcp
+    config:
+      worker-config:
+        genericWorker:
+          config:
+            # 2592000s is 30 days.
+            maxTaskRunTime: 2592000
+            enableInteractive: true
+            enableD2G: true
+            containerEngine: docker
+            ed25519SigningKeyLocation: '/etc/generic-worker/ed25519_key'
+      minCapacity: 0
+      # We use 4 GPUs per instance across 4 regions with a limit of 128
+      # per region at any given time. 4 regions * 4 GPUs = 512 total GPUs
+      # 512 GPUs / 4 per instance = 128 instances possibly running at once.
+      maxCapacity: 128
+      implementation: generic-worker/worker-runner-linux-multi
+      regions: [us-central1, us-west1, us-east1, europe-west4]
+      image: ubuntu-2404-headless-alpha
+      instance_types:
+        - minCpuPlatform: Intel Skylake
+          disks:
+            - <<: *persistent-disk
+              diskSizeGb: 75
+          machine_type: n1-highmem-8
+          guestAccelerators:
+            - acceleratorCount: 4
+              acceleratorType: nvidia-tesla-v100
+  - pool_id: '{pool-group}/b-linux-v100-gpu-d2g-4-300gb'
+    description: Worker for machine learning and other high GPU tasks
+    owner: release+tc-workers@mozilla.com
+    variants:
+      - pool-group: translations-1
+    email_on_error: true
+    provider_id:
+      by-chain-of-trust:
+        trusted: fxci-level3-gcp
+        default: fxci-level1-gcp
+    config:
+      worker-config:
+        genericWorker:
+          config:
+            # 2592000s is 30 days.
+            maxTaskRunTime: 2592000
+            enableInteractive: true
+            enableD2G: true
+            containerEngine: docker
+            ed25519SigningKeyLocation: '/etc/generic-worker/ed25519_key'
+      minCapacity: 0
+      # We use 4 GPUs per instance across 4 regions with a limit of 128
+      # per region at any given time. 4 regions * 4 GPUs = 512 total GPUs
+      # 512 GPUs / 4 per instance = 128 instances possibly running at once.
+      maxCapacity: 128
+      implementation: generic-worker/worker-runner-linux-multi
+      regions: [us-central1, us-west1, us-east1, europe-west4]
+      image: ubuntu-2404-headless-alpha
+      instance_types:
+        - minCpuPlatform: Intel Skylake
+          disks:
+            - <<: *persistent-disk
+              diskSizeGb: 300
           # 40 CPUs, 256GB RAM
           machine_type: n1-custom-40-262144
           guestAccelerators:


### PR DESCRIPTION
The existing ones are not used in production, so there's no real risk to doing this.