### PR TITLE
Disable Generic Worker interactive and D2G features by default

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -60,6 +60,8 @@ worker-defaults:
             disableReboots: false
             downloadsDir: Z:\downloads
             ed25519SigningKeyLocation: C:\generic-worker\ed25519-private.key
+            enableD2G: false
+            enableInteractive: false
             livelogExecutable: C:\generic-worker\livelog.exe
             livelogPUTPort: 60022
             numberOfTasksToRun: 0


### PR DESCRIPTION
Disable features unless explicitly enabled:
* Interactive
* D2G

Worker pools have can opt in to these features, but without explicitly enabling, they will be disabled.