### PR TITLE
Allow code-review developers to get the trigger token for their hooks

### DIFF
--- a/grants.yml
+++ b/grants.yml
@@ -2543,6 +2543,8 @@
     - assume:repo:github.com/mozilla/code-review:pull-request
     # Allow code-review developers to trigger their hooks
     - hooks:trigger-hook:project-relman/code-review-*
+    # Allow code-review developers to get the trigger token for their hooks
+    - hooks:get-trigger-token:project-relman/code-review-*
   to:
     - group:
         - code-review-developers


### PR DESCRIPTION
Refs https://bugzilla.mozilla.org/show_bug.cgi?id=1934254

With this scope, code-review bot developers can retrieve the trigger token  for existing code review hooks so that Phabricator could trigger it.