### PR TITLE
ci: ignore android-hw and macosx integration tests

### DIFF
--- a/taskcluster/fxci_config_taskgraph/util/integration.py
+++ b/taskcluster/fxci_config_taskgraph/util/integration.py
@@ -41,7 +41,11 @@ def find_tasks(decision_index_path: str) -> list[dict[str, Any]]:
     tasks = []
     for task in task_graph.values():
         assert isinstance(task, dict)
-        if task.get("attributes", {}).get("unittest_variant") != "os-integration":
+        attributes = task.get("attributes", {})
+        if attributes.get("unittest_variant") != "os-integration":
+            continue
+
+        if attributes.get("test_platform", "").startswith(("android-hw", "macosx")):
             continue
 
         tasks.append(task["task"])


### PR DESCRIPTION
Due to an oversight on the Gecko side, we accidentally scheduled a Bitbar test. This will be fixed the next time the cron task runs, but this acts as an extra safeguard.