### PR TITLE
Use payload from triggerHookWithToken in code-review-testing hook

### DIFF
--- a/hooks.yml
+++ b/hooks.yml
@@ -157,14 +157,14 @@ project-relman/code-review-testing:
         properties:
           type:
             type: string
-            descritpion: Phabricator object's type triggering the hook
+            description: Phabricator object's type triggering the hook
           phid:
             type: string
-            descritpion: Phabricator object's PHID triggering the hook
+            description: Phabricator object's PHID triggering the hook
 
       # Trigger hook from pulse for analyzing results
       runId:
-        type: string
+        type: int
         description: Taskcluster Task Run ID triggering the hook (should be a Try Task run)
       status:
         type: object

--- a/hooks.yml
+++ b/hooks.yml
@@ -146,6 +146,38 @@ project-relman/code-review-testing:
   trigger_schema:
     type: object
     additionalProperties: true
+    properties:
+
+      # Trigger hook with token payload to create a try push
+      object:
+        type: object
+        required:
+          - type
+          - phid
+        properties:
+          type:
+            type: string
+            descritpion: Phabricator object's type triggering the hook
+          phid:
+            type: string
+            descritpion: Phabricator object's PHID triggering the hook
+
+      # Trigger hook from pulse for analyzing results
+      runId:
+        type: string
+        description: Taskcluster Task Run ID triggering the hook (should be a Try Task run)
+      status:
+        type: object
+        required:
+          - taskId
+          - taskGroupId
+        properties:
+          taskId:
+            type: string
+            description: Taskcluster Task ID triggering the hook (should be a Try Task)
+          taskGroupId:
+            type: string
+            description: Taskcluster Task Group ID triggering the hook (should be a Try Task Group)
 
 project-relman/code-review-production:
   name: Code review hook (production)

--- a/hooks.yml
+++ b/hooks.yml
@@ -161,6 +161,17 @@ project-relman/code-review-testing:
           phid:
             type: string
             description: Phabricator object's PHID triggering the hook
+      transactions:
+        type: array
+        description: Phabricator transactions leading to this trigger
+        items:
+          type: object
+          required:
+            - phid
+          properties:
+            phid:
+              type: string
+              description: Phabricator transaction's PHID
 
       # Trigger hook from pulse for analyzing results
       runId:

--- a/hooks/project-relman/code-review-testing.yml
+++ b/hooks/project-relman/code-review-testing.yml
@@ -31,6 +31,13 @@ payload:
         else: {}
         then:
           $eval: payload
+      - $if: firedBy == 'triggerHookWithToken'
+        else: {}
+        then:
+          PHABRICATOR_OBJECT_TYPE:
+            $eval: payload.object.type
+          PHABRICATOR_OBJECT_PHID:
+            $eval: payload.object.phid
       - $if: firedBy == 'pulseMessage'
         else: {}
         then:

--- a/hooks/project-relman/code-review-testing.yml
+++ b/hooks/project-relman/code-review-testing.yml
@@ -34,10 +34,16 @@ payload:
       - $if: firedBy == 'triggerHookWithToken'
         else: {}
         then:
-          PHABRICATOR_OBJECT_TYPE:
-            $eval: payload.object.type
-          PHABRICATOR_OBJECT_PHID:
-            $eval: payload.object.phid
+          $let:
+            transactions:
+              $map: {$eval: payload.transactions}
+              each(transaction): {$eval: transaction.phid}
+          in:
+            PHABRICATOR_OBJECT_TYPE:
+              $eval: payload.object.type
+            PHABRICATOR_OBJECT_PHID:
+              $eval: payload.object.phid
+            PHABRICATOR_TRANSACTIONS: {$json: {$eval: transactions}}
       - $if: firedBy == 'pulseMessage'
         else: {}
         then:


### PR DESCRIPTION
Refs https://github.com/mozilla/code-review/issues/2518

The goal of that PR is to support payloads sent by Phabricator webhooks using `triggerHookWithToken` Taskcluster API call, without altering the other triggers (direct & from pulse).

The payload sent by Phabricator is described on [that bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1935142#c6):

```json
{
  "object": {
    "type": "DREV",
    "phid": "PHID-DREV-cljdgxaey4cxvxb4knjp"
  },
...
}
```

I only need the object type & phid as environment variables in the created task for now.