### PR TITLE
Add the `web:read-pulse` scope to the `anonymous` role

### DIFF
--- a/grants.yml
+++ b/grants.yml
@@ -2806,6 +2806,7 @@
     - queue:pending-count:*
     - queue:status:*
     - secrets:list-secrets
+    - web:read-pulse
     - worker-manager:get-worker-pool:*
     - worker-manager:get-worker:*
     - worker-manager:list-providers


### PR DESCRIPTION
Taskcluster made the pulse messages private by default in https://github.com/taskcluster/taskcluster/pull/7377

This commit adds the newly required scope to keep the current status of it being open