### PR TITLE
Bug 1935607 - cron tasks for automated merge day dry runs fail because a lack of scopes

### DIFF
--- a/grants.yml
+++ b/grants.yml
@@ -571,6 +571,20 @@
         alias: [mozilla-beta]
 
 - grant:
+    - hooks:trigger-hook:project-gecko/in-tree-action-3-merge-automation/*
+  to:
+    - project:
+        job: [cron:merge-beta-to-release-dry-run]
+        trust_domain: gecko
+        level: [3]
+        alias: [mozilla-beta]
+    - project:
+        job: [cron:merge-central-to-beta-dry-run]
+        trust_domain: gecko
+        level: [3]
+        alias: [mozilla-central]
+
+- grant:
     - queue:create-task:{priority}:scriptworker-k8s/gecko-3-tree
   to:
     - project:


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1935607