### PR TITLE
feat: translations integration tests

### DIFF
--- a/taskcluster/fxci_config_taskgraph/transforms/firefoxci_artifact.py
+++ b/taskcluster/fxci_config_taskgraph/transforms/firefoxci_artifact.py
@@ -25,10 +25,14 @@ def make_firefoxci_artifact_tasks(config, tasks):
         tasks_to_create = defaultdict(list)
         include_attrs = task.pop("include-attrs", {})
         exclude_attrs = task.pop("exclude-attrs", {})
+        include_deps = task.pop("include-deps", [])
         for decision_index_path in task.pop("decision-index-paths"):
             for task_def in find_tasks(
-                decision_index_path, include_attrs, exclude_attrs
-            ):
+                decision_index_path,
+                include_attrs,
+                exclude_attrs,
+                include_deps,
+            ).values():
                 # Add docker images
                 if "image" in task_def["payload"]:
                     image = task_def["payload"]["image"]

--- a/taskcluster/fxci_config_taskgraph/transforms/firefoxci_artifact.py
+++ b/taskcluster/fxci_config_taskgraph/transforms/firefoxci_artifact.py
@@ -4,6 +4,7 @@
 
 import json
 import os
+import re
 from collections import defaultdict
 from copy import deepcopy
 
@@ -26,6 +27,14 @@ def make_firefoxci_artifact_tasks(config, tasks):
         include_attrs = task.pop("include-attrs", {})
         exclude_attrs = task.pop("exclude-attrs", {})
         include_deps = task.pop("include-deps", [])
+        # Mirror public artifacts is a bit weird; you would expect that you
+        # could just pull them from the firefox ci cluster instead, but it
+        # turns out to be necessary when you we're running integration tests
+        # on tasks that have fetches from a non-mirrored task in the firefox ci
+        # cluster as well as a mirrored task in the staging cluster.
+        mirror_public_fetches = [
+            re.compile(r) for r in task.pop("mirror-public-fetches", [])
+        ]
         for decision_index_path in task.pop("decision-index-paths"):
             for task_def in find_tasks(
                 decision_index_path,
@@ -36,14 +45,10 @@ def make_firefoxci_artifact_tasks(config, tasks):
                 # Add docker images
                 if "image" in task_def["payload"]:
                     image = task_def["payload"]["image"]
-                    if not isinstance(image, dict) or "taskId" not in image:
-                        continue
-
-                    task_id = image["taskId"]
-                    if task_id in tasks_to_create:
-                        continue
-
-                    tasks_to_create[task_id] = [image["path"]]
+                    if isinstance(image, dict) and "taskId" in image:
+                        task_id = image["taskId"]
+                        if task_id not in tasks_to_create:
+                            tasks_to_create[task_id] = [image["path"]]
 
                 # Add private artifacts
                 if "MOZ_FETCHES" in task_def["payload"].get("env", {}):
@@ -52,7 +57,13 @@ def make_firefoxci_artifact_tasks(config, tasks):
                     )
                     for fetch in fetches:
                         if fetch["artifact"].startswith("public"):
-                            continue
+                            if not any(
+                                [
+                                    pat.match(task_def["metadata"]["name"])
+                                    for pat in mirror_public_fetches
+                                ]
+                            ):
+                                continue
 
                         task_id = fetch["task"]
                         tasks_to_create[task_id].append(fetch["artifact"])

--- a/taskcluster/fxci_config_taskgraph/util/integration.py
+++ b/taskcluster/fxci_config_taskgraph/util/integration.py
@@ -130,7 +130,7 @@ def find_tasks(
             if attrmatch(attributes, **excludes):
                 continue
 
-        tasks[task_id] = task["task"]
+        tasks[task_id] = _rewrite_task_datestamps(task["task"])
         # get_ancestors can be expensive; don't run it unless we might actually
         # use the results.
         if include_deps:

--- a/taskcluster/fxci_config_taskgraph/util/integration.py
+++ b/taskcluster/fxci_config_taskgraph/util/integration.py
@@ -2,14 +2,36 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import os
+import re
 from functools import cache
 from typing import Any
 
 import requests
 import taskcluster
 from taskgraph.util.attributes import attrmatch
+from taskgraph.util.taskcluster import get_ancestors as taskgraph_get_ancestors
+from taskgraph.util.taskcluster import get_root_url
 
 from fxci_config_taskgraph.util.constants import FIREFOXCI_ROOT_URL
+
+
+def get_ancestors(task_ids: list[str] | str) -> dict[str, str]:
+    # This is not ideal, but at the moment we don't have a better way
+    # to ensure that the upstream get_ancestors talks to the correct taskcluster
+    # instance.
+    orig = os.environ["TASKCLUSTER_ROOT_URL"]
+    try:
+        # Cache needs to be cleared here to allow `get_root_url` to ensure that
+        # `get_root_url` is called again after a change.
+        get_root_url.cache_clear()
+        os.environ["TASKCLUSTER_ROOT_URL"] = FIREFOXCI_ROOT_URL
+        ret = taskgraph_get_ancestors(task_ids)
+    finally:
+        os.environ["TASKCLUSTER_ROOT_URL"] = orig
+        get_root_url.cache_clear()
+
+    return ret
 
 
 @cache
@@ -19,7 +41,7 @@ def get_taskcluster_client(service: str):
 
 
 @cache
-def _fetch_task_graph(decision_index_path: str) -> list[dict[str, Any]]:
+def _fetch_task_graph(decision_index_path: str) -> dict[str, dict[str, Any]]:
     """Fetch a decision task's `task-graph.json` given by the
     `decision-index-path`. This is done separately from `find_tasks`
     because the @cache decorator does not work with the `dict` parameters
@@ -41,20 +63,60 @@ def _fetch_task_graph(decision_index_path: str) -> list[dict[str, Any]]:
     else:
         task_graph = response
 
-    return task_graph.values()
+    return task_graph
+
+
+@cache
+def _queue_task(task_id):
+    queue = get_taskcluster_client("queue")
+    return queue.task(task_id)
+
+
+def _rewrite_task_datestamps(task_def):
+    """Rewrite absolute datestamps from a concrete task definition into
+    relative ones that can then be used to schedule a new task."""
+    # Arguably, we should try to figure out what these values should be from
+    # the repo that created them originally. In practice it probably doesn't
+    # matter.
+    task_def["created"] = {"relative-datestamp": "0 seconds"}
+    task_def["deadline"] = {"relative-datestamp": "1 day"}
+    task_def["expires"] = {"relative-datestamp": "1 month"}
+
+    if "payload" in task_def:
+        if "artifacts" in task_def["payload"]:
+            if isinstance(task_def["payload"]["artifacts"], dict):
+                for key, _ in task_def["payload"]["artifacts"].items():
+                    if "expires" in task_def["payload"]["artifacts"][key]:
+                        task_def["payload"]["artifacts"][key]["expires"] = {
+                            "relative-datestamp": "1 month"
+                        }
+            elif isinstance(task_def["payload"]["artifacts"], list):
+                new_artifacts = []
+                for a in task_def["payload"]["artifacts"]:
+                    if "expires" in a:
+                        a["expires"] = {"relative-datestamp": "1 month"}
+                    new_artifacts.append(a)
+                task_def["payload"]["artifacts"] = new_artifacts
+
+    return task_def
 
 
 def find_tasks(
     decision_index_path: str,
     include_attrs: dict[str, list[str]],
     exclude_attrs: dict[str, list[str]],
-) -> list[dict[str, Any]]:
-    """Find tasks targeted by the Decision task pointed to by `decision_index_path`
-    that match the the included and excluded attributes given.
+    include_deps: list[str],
+) -> dict[str, dict[str, Any]]:
+    """Find and return tasks targeted by the Decision task pointed to by
+    `decision_index_path` that match the the included and excluded attributes
+    given. Any tasks upstream of a targeted task will also be returned if
+    their label matches any pattern given in `include_deps`. (Note that
+    attributes _cannot_ be used to filter upstream tasks, as we only have
+    access to task definitions for these tasks.)
     """
-    tasks = []
+    tasks = {}
 
-    for task in _fetch_task_graph(decision_index_path):
+    for task_id, task in _fetch_task_graph(decision_index_path).items():
         assert isinstance(task, dict)
         attributes = task.get("attributes", {})
         excludes = {
@@ -66,6 +128,29 @@ def find_tasks(
         ):
             continue
 
-        tasks.append(task["task"])
+        tasks[task_id] = task["task"]
+        # get_ancestors can be expensive; don't run it unless we might actually
+        # use the results.
+        if include_deps:
+            patterns = [re.compile(p) for p in include_deps]
+            for upstream_task_id, label in get_ancestors(task_id).items():
+                if any([pat.match(label) for pat in patterns]):
+                    task_def = _queue_task(upstream_task_id)
+                    # The task definitions from `get_ancestors` are fully
+                    # concrete, unlike the ones that `_fetch_task_graph`
+                    # returns, which have certain things missing or in a
+                    # different form. We need to massage the former to look
+                    # like the latter to allow callers to treat them the same.
+
+                    # `taskQueueId` should never be present, because it will
+                    # never match what it ought to be when we reschedule tasks
+                    # in staging.
+                    if "taskQueueId" in task_def:
+                        del task_def["taskQueueId"]
+
+                    # All datestamps come in as absolute ones, many of which
+                    # will be in the past. We need to rewrite these to relative
+                    # ones to make the task reschedulable.
+                    tasks[upstream_task_id] = _rewrite_task_datestamps(task_def)
 
     return tasks

--- a/taskcluster/fxci_config_taskgraph/util/integration.py
+++ b/taskcluster/fxci_config_taskgraph/util/integration.py
@@ -119,14 +119,16 @@ def find_tasks(
     for task_id, task in _fetch_task_graph(decision_index_path).items():
         assert isinstance(task, dict)
         attributes = task.get("attributes", {})
-        excludes = {
-            key: lambda attr: any([attr.startswith(v) for v in values])
-            for key, values in exclude_attrs.items()
-        }
-        if not attrmatch(attributes, **include_attrs) or attrmatch(
-            attributes, **excludes
-        ):
+        if not attrmatch(attributes, **include_attrs):
             continue
+
+        if exclude_attrs:
+            excludes = {
+                key: lambda attr: any([attr.startswith(v) for v in values])
+                for key, values in exclude_attrs.items()
+            }
+            if attrmatch(attributes, **excludes):
+                continue
 
         tasks[task_id] = task["task"]
         # get_ancestors can be expensive; don't run it unless we might actually

--- a/taskcluster/kinds/firefoxci-artifact/kind.yml
+++ b/taskcluster/kinds/firefoxci-artifact/kind.yml
@@ -41,3 +41,24 @@ tasks:
       test_platform:
         - android-hw
         - macosx
+
+  translations:
+    description: "Fetch artifacts from Firefox-CI for translations pipeline tests"
+    decision-index-paths:
+      - translations.v2.translations.latest.taskgraph.decision-run-pipeline
+    include-attrs:
+      # Corresponds to https://github.com/mozilla/translations/blob/main/taskcluster/kinds/all-pipeline/kind.yml
+      stage:
+        - all-pipeline
+    include-deps:
+      # Decision and Action tasks are excluded because we'll be creating the
+      # tasks they normally would be.
+      # docker-image tasks are excluded because there's no value in rerunning
+      # them as part of integration tests.
+      # fetch tasks are excluded because there's no value in rerunning them,
+      # and also because they live forever, and depend on docker images which
+      # expire, which causes us to try to mirror expired docker image tasks
+      # into the staging cluster
+      - ^(?!(Decision|Action|PR action|build-docker-image|fetch)).*
+    mirror-public-fetches:
+      - ^toolchain.*

--- a/taskcluster/kinds/integration-test/kind.yml
+++ b/taskcluster/kinds/integration-test/kind.yml
@@ -23,3 +23,22 @@ tasks:
       test_platform:
         - android-hw
         - macosx
+
+  translations:
+    description: "Run translations pipeline integration tests"
+    decision-index-paths:
+      - translations.v2.translations.latest.taskgraph.decision-run-pipeline
+    include-attrs:
+      # Corresponds to https://github.com/mozilla/translations/blob/main/taskcluster/kinds/all-pipeline/kind.yml
+      stage:
+        - all-pipeline
+    include-deps:
+      # Decision and Action tasks are excluded because we'll be creating the
+      # tasks they normally would be.
+      # docker-image tasks are excluded because there's no value in rerunning
+      # them as part of integration tests.
+      # fetch tasks are excluded because there's no value in rerunning them,
+      # and also because they live forever, and depend on docker images which
+      # expire, which causes us to try to mirror expired docker image tasks
+      # into the staging cluster
+      - ^(?!(Decision|Action|PR action|build-docker-image|fetch)).*

--- a/taskcluster/test/test_transforms_firefoxci_artifact.py
+++ b/taskcluster/test/test_transforms_firefoxci_artifact.py
@@ -56,6 +56,7 @@ def run_test(monkeypatch, run_transform, responses):
             "test_platform": ["android-hw", "macosx"]
         },
         include_deps: list[str] = [],
+        mirror_public_fetches: list[str] = [],
         name: str = task_label,
     ) -> dict[str, Any] | None:
         _fetch_task_graph.cache_clear()
@@ -90,6 +91,7 @@ def run_test(monkeypatch, run_transform, responses):
             "include-attrs": include_attrs,
             "exclude-attrs": exclude_attrs,
             "include-deps": include_deps,
+            "mirror-public-fetches": mirror_public_fetches,
             "worker": {
                 "env": {
                     "MOZ_ARTIFACT_DIR": "/builds/worker/artifacts",
@@ -219,6 +221,26 @@ def test_private_fetch(run_test):
                 },
             },
         },
+        name="gecko",
+    )
+    assert_result({task_id: artifact}, "gecko", result)
+
+
+def test_included_public_fetch(run_test):
+    task_id = "def"
+    artifact = "public/build/foo.zip"
+    result = run_test(
+        {
+            "attributes": {"unittest_variant": "os-integration"},
+            "task": {
+                "payload": {
+                    "env": {
+                        "MOZ_FETCHES": f'[{{"task": "{task_id}", "artifact": "{artifact}"}}]'
+                    },
+                },
+            },
+        },
+        mirror_public_fetches=["^foo"],
         name="gecko",
     )
     assert_result({task_id: artifact}, "gecko", result)

--- a/taskcluster/test/test_transforms_firefoxci_artifact.py
+++ b/taskcluster/test/test_transforms_firefoxci_artifact.py
@@ -150,6 +150,24 @@ def test_private_fetch_no_attribute(run_test):
     assert result == []
 
 
+def test_no_exclude_attr_doesnt_reject_all_tasks(run_test):
+    result = run_test(
+        {
+            "attributes": {"unittest_variant": "os-integration"},
+            "task": {
+                "payload": {
+                    "image": {
+                        "taskId": "abc",
+                        "path": "public/build/image.tar.zst",
+                    }
+                }
+            },
+        },
+        exclude_attrs={},
+    )
+    assert len(result) == 1
+
+
 def assert_result(expected_tasks: dict[str, str], prefix, result):
     expected = []
     for task_id, artifact in expected_tasks.items():

--- a/taskcluster/test/test_transforms_integration_test.py
+++ b/taskcluster/test/test_transforms_integration_test.py
@@ -166,6 +166,9 @@ def test_basic(run_test):
             ],
         },
         "task": {
+            "created": {"relative-datestamp": "0 seconds"},
+            "deadline": {"relative-datestamp": "1 day"},
+            "expires": {"relative-datestamp": "1 month"},
             "extra": {},
             "metadata": {"description": "test", "name": "gecko-foo"},
             "payload": {"command": ""},

--- a/taskcluster/test/test_transforms_integration_test.py
+++ b/taskcluster/test/test_transforms_integration_test.py
@@ -424,7 +424,8 @@ def run_include_deps_test(run_test, *args, **kwargs):
                                 "task": "toolchain1",
                             },
                         ]
-                    )
+                    ),
+                    "FOO_REV": "abc123",
                 },
             },
             "tags": {},
@@ -532,6 +533,10 @@ def run_include_deps_test(run_test, *args, **kwargs):
             for a in artifacts:
                 assert isinstance(a["expires"], dict)
                 assert "relative-datestamp" in a["expires"]
+
+        # verify that `FOO_REV` is gone
+        if t["payload"].get("env", {}).get("FOO_REV"):
+            assert False, "FOO_REV should've been removed"
 
     return ret
 


### PR DESCRIPTION
This adds support for running the translations training pipeline as part of integration tests. The first two commits, which add support for fetching upstream tasks that didn't run as part of a decision task and support for rewriting dependencies to the yet-to-be-scheduled tasks are the interesting parts. The other few commits are pretty boring, and simply fix a minor bug and enable the translations tests.

Note that these depends on https://github.com/mozilla-releng/fxci-config/pull/228, a yet to be opened PR in https://github.com/mozilla/translations to add a pipeline cronjob. It's currently running against the staging repository and working well though.