### PR TITLE
ci: remove 'continue-on-error' from deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: check
     environment: apply-${{matrix.environment}}
-    continue-on-error: true
     strategy:
       matrix:
         environment: ["firefoxci"]


### PR DESCRIPTION
It appears that setting this will cause the 'apply' job to report a successful status even if it failed, which is not what we want.

We want the `notify` job to run regardless of whether its dependencies were successful or not. From the docs, it looks like setting `if: always()` should already accomplish this. Therefore I think it's safe to remove `continue-on-error`.