### PR TITLE
ci(integration): turn firefoxci-artifact tasks into cached_tasks

### DIFF
--- a/taskcluster/kinds/firefoxci-artifact/kind.yml
+++ b/taskcluster/kinds/firefoxci-artifact/kind.yml
@@ -6,10 +6,12 @@ loader: taskgraph.loader.transform:loader
 
 transforms:
   - fxci_config_taskgraph.transforms.firefoxci_artifact
+  - taskgraph.transforms.cached_tasks
   - taskgraph.transforms.run
   - taskgraph.transforms.task
 
 task-defaults:
+  attributes: {}  # cached_tasks transforms assume this exists
   worker-type: t-linux
   worker:
     docker-image: {in-tree: python3.11}


### PR DESCRIPTION
I was debating not using the `cached_tasks` transforms and just setting up the index-search optimization manually due to there not being any digest-data.. but I guess this way it'll still work if we ever add any dependencies to these tasks.