### PR TITLE
silly change to test possible issue with taskcluster upgrade

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -382,7 +382,7 @@ pools:
             - *scratch-disk
           machine_type: n2-standard-32
   - pool_id: '{pool-group}/b-linux-large-gcp-d2g'
-    description: Workers using generic-worker on Linux with D2G capability.
+    description: Workers using generic-worker on Linux with D2G capability
     owner: release+tc-workers@mozilla.com
     email_on_error: true
     variants:


### PR DESCRIPTION
I'm seeing integration tests fail to schedule and/or find docker images in https://github.com/mozilla-releng/fxci-config/pull/210 after pulling in a recent taskgraph upgrade. I'm going to try repro'ing here to disentangle what's at fault.