### PR TITLE
ci(integration): add tests for integration related transforms and scr…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,6 @@ ignore = [
 [tool.ruff.lint.isort]
 known-first-party = ["ciadmin", "build_decision", "fxci_config_taskgraph"]
 known-third-party = ["taskcluster", "tcadmin", "taskgraph"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests", "taskcluster/test"]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -484,7 +484,7 @@ click==8.1.7 \
     --hash=sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28 \
     --hash=sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de
     # via tc-admin
-colorama==0.4.6 ; sys_platform == 'win32' or platform_system == 'Windows' \
+colorama==0.4.6 ; platform_system == 'Windows' or sys_platform == 'win32' \
     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
     # via

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1149,6 +1149,7 @@ pytest==8.3.3 \
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-mock
+    #   pytest-taskgraph
     #   tc-admin
 pytest-asyncio==0.24.0 \
     --hash=sha256:a811296ed596b69bf0b6f3dc40f83bcaf341b155a269052d82efa2b25ac7037b \
@@ -1161,6 +1162,10 @@ pytest-cov==6.0.0 \
 pytest-mock==3.14.0 \
     --hash=sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f \
     --hash=sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0
+    # via -r test.in
+pytest-taskgraph==0.1.0 \
+    --hash=sha256:1e75f83df177c4794b37725dccf6944430331fb46d5e900cd2bab7c9cfdafa81 \
+    --hash=sha256:bd2a93aafaefc3accc769a6fc2ed86679829a0b0e7b12867aeb46e2fd8a4cae4
     # via -r test.in
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
@@ -1288,10 +1293,12 @@ taskcluster==67.0.1 \
     # via
     #   -r base.in
     #   tc-admin
-taskcluster-taskgraph==12.0.0 \
-    --hash=sha256:7554e8709552918a66f03029134aa99a5c9414a839962d84c00e84ee848ab97e \
-    --hash=sha256:96a6b04bb349621664d15bbb5856018175ce85999d6e0293374603f804c7234b
-    # via -r test.in
+taskcluster-taskgraph==12.1.0 \
+    --hash=sha256:222ba9f729e6d970de8c177251e3a5f29010332d7cc6ca8967fd8c8b73fa2c1b \
+    --hash=sha256:c37b0ff65ab6ae3ae322bf1ecd4d3453db01b37f22164d9a33ab77e634a34d9a
+    # via
+    #   -r test.in
+    #   pytest-taskgraph
 taskcluster-urls==13.0.1 \
     --hash=sha256:5e25e7e6818e8877178b175ff43d2e6548afad72694aa125f404a7329ece0973 \
     --hash=sha256:b25e122ecec249c4299ac7b20b08db76e3e2025bdaeb699a9d444556de5fd367 \

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -6,4 +6,6 @@ pip>=21.2
 pytest
 pytest-cov
 pytest-mock
-taskcluster-taskgraph
+pytest-taskgraph >= 0.1.0
+responses >= 0.25.3
+taskcluster-taskgraph >= 12.1.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -510,7 +510,7 @@ click==8.1.7 \
     # via
     #   cookiecutter
     #   tc-admin
-colorama==0.4.6 ; (platform_system != 'Windows' and sys_platform == 'win32') or platform_system == 'Windows' or os_name == 'nt' \
+colorama==0.4.6 ; os_name == 'nt' or (platform_system == 'Windows' and sys_platform != 'win32') or sys_platform == 'win32' \
     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
     # via
@@ -1118,6 +1118,7 @@ pytest==8.3.3 \
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-mock
+    #   pytest-taskgraph
     #   tc-admin
 pytest-asyncio==0.24.0 \
     --hash=sha256:a811296ed596b69bf0b6f3dc40f83bcaf341b155a269052d82efa2b25ac7037b \
@@ -1130,6 +1131,10 @@ pytest-cov==6.0.0 \
 pytest-mock==3.14.0 \
     --hash=sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f \
     --hash=sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0
+    # via -r test.in
+pytest-taskgraph==0.1.0 \
+    --hash=sha256:1e75f83df177c4794b37725dccf6944430331fb46d5e900cd2bab7c9cfdafa81 \
+    --hash=sha256:bd2a93aafaefc3accc769a6fc2ed86679829a0b0e7b12867aeb46e2fd8a4cae4
     # via -r test.in
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
@@ -1198,6 +1203,7 @@ pyyaml==6.0.2 \
     # via
     #   -r base.in
     #   cookiecutter
+    #   responses
     #   taskcluster-taskgraph
     #   tc-admin
 redo==3.0.0 \
@@ -1211,6 +1217,7 @@ requests==2.32.3 \
     #   cookiecutter
     #   gql
     #   requests-toolbelt
+    #   responses
     #   simple-github
     #   taskcluster
     #   taskcluster-taskgraph
@@ -1218,6 +1225,10 @@ requests-toolbelt==1.0.0 \
     --hash=sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6 \
     --hash=sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06
     # via gql
+responses==0.25.3 \
+    --hash=sha256:521efcbc82081ab8daa588e08f7e8a64ce79b91c39f6e62199b19159bea7dbcb \
+    --hash=sha256:617b9247abd9ae28313d57a75880422d55ec63c29d33d629697590a034358dba
+    # via -r test.in
 rich==13.9.4 \
     --hash=sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098 \
     --hash=sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90
@@ -1257,10 +1268,12 @@ taskcluster==67.0.1 \
     # via
     #   -r base.in
     #   tc-admin
-taskcluster-taskgraph==12.0.0 \
-    --hash=sha256:7554e8709552918a66f03029134aa99a5c9414a839962d84c00e84ee848ab97e \
-    --hash=sha256:96a6b04bb349621664d15bbb5856018175ce85999d6e0293374603f804c7234b
-    # via -r test.in
+taskcluster-taskgraph==12.1.0 \
+    --hash=sha256:222ba9f729e6d970de8c177251e3a5f29010332d7cc6ca8967fd8c8b73fa2c1b \
+    --hash=sha256:c37b0ff65ab6ae3ae322bf1ecd4d3453db01b37f22164d9a33ab77e634a34d9a
+    # via
+    #   -r test.in
+    #   pytest-taskgraph
 taskcluster-urls==13.0.1 \
     --hash=sha256:5e25e7e6818e8877178b175ff43d2e6548afad72694aa125f404a7329ece0973 \
     --hash=sha256:b25e122ecec249c4299ac7b20b08db76e3e2025bdaeb699a9d444556de5fd367 \
@@ -1283,7 +1296,9 @@ types-python-dateutil==2.9.0.20241003 \
 urllib3==2.2.3 \
     --hash=sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac \
     --hash=sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9
-    # via requests
+    # via
+    #   requests
+    #   responses
 voluptuous==0.15.2 \
     --hash=sha256:016348bc7788a9af9520b1764ebd4de0df41fe2138ebe9e06fa036bf86a65566 \
     --hash=sha256:6ffcab32c4d3230b4d2af3a577c87e1908a714a11f6f95570456b1849b0279aa

--- a/taskcluster/fxci_config_taskgraph/transforms/integration_test.py
+++ b/taskcluster/fxci_config_taskgraph/transforms/integration_test.py
@@ -68,7 +68,7 @@ def rewrite_mounts(task_def: dict[str, Any]) -> None:
             continue
 
         if "namespace" in content:
-            task_id = index.findTask(content["namespace"])
+            task_id = index.findTask(content["namespace"])["taskId"]
         else:
             assert "taskId" in content
             task_id = content["taskId"]

--- a/taskcluster/test/conftest.py
+++ b/taskcluster/test/conftest.py
@@ -1,0 +1,25 @@
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+
+import sys
+from pathlib import Path
+
+import pytest
+from responses import RequestsMock
+
+here = Path(__file__).parent
+sys.path.insert(0, str(here.parent))  # ensure fxci_config_taskgraph is importable
+
+pytest_plugins = ("pytest-taskgraph",)
+
+
+@pytest.fixture(scope="session")
+def datadir():
+    return here / "data"
+
+
+@pytest.fixture
+def responses():
+    with RequestsMock() as rsps:
+        yield rsps

--- a/taskcluster/test/test_transforms_integration_test.py
+++ b/taskcluster/test/test_transforms_integration_test.py
@@ -1,0 +1,296 @@
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+
+from pprint import pprint
+from typing import Any
+
+import pytest
+from taskgraph.util.copy import deepcopy
+from taskgraph.util.templates import merge
+
+from fxci_config_taskgraph.transforms.integration_test import transforms
+from fxci_config_taskgraph.util.integration import FIREFOXCI_ROOT_URL, find_tasks
+
+
+@pytest.fixture
+def run_test(run_transform, responses):
+    """This fixture returns a function that will execute the test.
+
+    Input to the function is a JSON object representing extra task config of a
+    single task that will be found on the index.
+
+    The fixture will return the result of running the `integration_test`
+    transforms on this task.
+    """
+    index = "foo.bar.baz"
+    decision_task_id = "abc"
+
+    task_label = "foo"
+    base_task = {
+        "attributes": {},
+        "task": {
+            "dependencies": [],
+            "extra": {},
+            "metadata": {"name": task_label, "description": "test"},
+            "payload": {"command": ""},
+            "tags": {},
+        },
+    }
+
+    responses.add(
+        responses.GET,
+        f"{FIREFOXCI_ROOT_URL}/api/index/v1/task/{index}",
+        json={"taskId": decision_task_id},
+    )
+
+    def inner(task: dict[str, Any]) -> dict[str, Any] | None:
+        find_tasks.cache_clear()
+
+        task = merge(deepcopy(base_task), task)
+        task_graph = {task_label: task}
+
+        responses.upsert(
+            responses.GET,
+            f"{FIREFOXCI_ROOT_URL}/api/queue/v1/task/{decision_task_id}/artifacts/public%2Ftask-graph.json",
+            json=task_graph,
+        )
+
+        result = run_transform(transforms, {"decision-index-paths": [index]})
+        if not result:
+            return None
+
+        assert len(result) == 1
+        result = result[0]
+        print("Dumping for copy/paste:")
+        pprint(result, indent=2)
+        return result
+
+    return inner
+
+
+def test_no_unittest_variant_skipped(run_test):
+    assert run_test({"attributes": {"foo": "bar"}}) is None
+
+
+def test_wrong_unittest_variant_skipped(run_test):
+    assert run_test({"attributes": {"unittest_variant": "something-else"}}) is None
+
+
+def test_macosx_skipped(run_test):
+    assert (
+        run_test(
+            {
+                "attributes": {
+                    "unittest_variant": "os-integration",
+                    "test_platform": "macosx1100",
+                }
+            }
+        )
+        is None
+    )
+
+
+def test_android_hw_skipped(run_test):
+    assert (
+        run_test(
+            {
+                "attributes": {
+                    "unittest_variant": "os-integration",
+                    "test_platform": "android-hw-4.0",
+                }
+            }
+        )
+        is None
+    )
+
+
+def test_basic(run_test):
+    result = run_test({"attributes": {"unittest_variant": "os-integration"}})
+    assert result == {
+        "attributes": {"integration": "gecko"},
+        "dependencies": {"apply": "tc-admin-apply-staging"},
+        "description": "test",
+        "label": "gecko-foo",
+        "task": {
+            "extra": {},
+            "metadata": {"description": "test", "name": "gecko-foo"},
+            "payload": {"command": ""},
+            "priority": "low",
+            "routes": ["checks"],
+            "schedulerId": "ci-level-1",
+            "tags": {},
+            "taskGroupId": "abc",
+        },
+    }
+
+
+def test_docker_image(run_test):
+    result = run_test(
+        {
+            "attributes": {"unittest_variant": "os-integration"},
+            "task": {"payload": {"image": {"taskId": "def"}}},
+        }
+    )
+    assert result["dependencies"] == {
+        "apply": "tc-admin-apply-staging",
+        "docker-image": "firefoxci-artifact-gecko-def",
+    }
+    assert result["task"]["payload"].get("image") == {
+        "path": "public/image.tar.zst",
+        "taskId": {"task-reference": "<docker-image>"},
+        "type": "task-image",
+    }
+
+
+def test_public_fetch_generic_worker(run_test):
+    result = run_test(
+        {
+            "attributes": {"unittest_variant": "os-integration"},
+            "task": {
+                "payload": {
+                    "command": [["chmod", "+x", "run-task"], ["cmd"]],
+                    "env": {
+                        "MOZ_FETCHES": '[{"task": "def", "artifact": "public/foo.txt"}]'
+                    },
+                },
+                "tags": {"worker-implementation": "generic-worker"},
+            },
+        }
+    )
+    assert result["dependencies"] == {"apply": "tc-admin-apply-staging"}
+    assert result["task"]["payload"]["command"] == [
+        ["chmod", "+x", "run-task"],
+        [
+            "bash",
+            "-c",
+            "TASKCLUSTER_ROOT_URL=https://firefox-ci-tc.services.mozilla.com cmd",
+        ],
+    ]
+
+
+def test_public_fetch_generic_worker_windows(run_test):
+    result = run_test(
+        {
+            "attributes": {"unittest_variant": "os-integration"},
+            "task": {
+                "payload": {
+                    "command": ["cmd"],
+                    "env": {
+                        "MOZ_FETCHES": '[{"task": "def", "artifact": "public/foo.txt"}]'
+                    },
+                },
+                "tags": {"os": "windows", "worker-implementation": "generic-worker"},
+            },
+        }
+    )
+    assert result["dependencies"] == {"apply": "tc-admin-apply-staging"}
+    assert result["task"]["payload"]["command"] == [
+        'set "TASKCLUSTER_ROOT_URL=https://firefox-ci-tc.services.mozilla.com" & cmd'
+    ]
+
+
+def test_public_fetch_docker_worker(run_test):
+    result = run_test(
+        {
+            "attributes": {"unittest_variant": "os-integration"},
+            "task": {
+                "payload": {
+                    "command": ["cmd"],
+                    "env": {
+                        "MOZ_FETCHES": '[{"task": "def", "artifact": "public/foo.txt"}]'
+                    },
+                }
+            },
+        }
+    )
+    assert result["dependencies"] == {"apply": "tc-admin-apply-staging"}
+    assert result["task"]["payload"]["command"] == [
+        "bash",
+        "-c",
+        "TASKCLUSTER_ROOT_URL=https://firefox-ci-tc.services.mozilla.com " "cmd",
+    ]
+
+
+def test_private_artifact(run_test):
+    result = run_test(
+        {
+            "attributes": {"unittest_variant": "os-integration"},
+            "task": {
+                "payload": {
+                    "command": ["cmd"],
+                    "env": {"MOZ_FETCHES": '[{"task": "def", "artifact": "foo.txt"}]'},
+                }
+            },
+        }
+    )
+    assert result["dependencies"] == {
+        "apply": "tc-admin-apply-staging",
+        "fetch-def": "firefoxci-artifact-gecko-def",
+    }
+    assert result["task"]["payload"]["env"]["MOZ_FETCHES"] == {
+        "task-reference": '[{"task": "<fetch-def>", "artifact": "foo.txt"}]'
+    }
+
+
+def test_mounts_task_id(run_test):
+    result = run_test(
+        {
+            "attributes": {"unittest_variant": "os-integration"},
+            "task": {
+                "payload": {
+                    "mounts": [
+                        {"content": {"taskId": "def", "artifact": "public/foo.txt"}}
+                    ]
+                }
+            },
+        }
+    )
+    assert result["task"]["payload"]["mounts"] == [
+        {
+            "content": {
+                "url": "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/def/artifacts/public/foo.txt"
+            }
+        }
+    ]
+
+
+def test_mounts_namespace(run_test):
+    result = run_test(
+        {
+            "attributes": {"unittest_variant": "os-integration"},
+            "task": {
+                "payload": {
+                    "mounts": [
+                        {
+                            "content": {
+                                "namespace": "foo.bar.baz",
+                                "artifact": "public/foo.txt",
+                            }
+                        }
+                    ]
+                }
+            },
+        }
+    )
+    assert result["task"]["payload"]["mounts"] == [
+        {
+            "content": {
+                "url": "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/abc/artifacts/public/foo.txt"
+            }
+        }
+    ]
+
+
+def test_docker_cache(run_test):
+    result = run_test(
+        {
+            "attributes": {"unittest_variant": "os-integration"},
+            "task": {
+                "payload": {"cache": {"gecko-level-3": "path"}},
+                "scopes": ["cache:gecko-level-3"],
+            },
+        }
+    )
+    assert result["task"]["payload"]["cache"] == {"ci-level-1": "path"}
+    assert result["task"]["scopes"] == ["cache:ci-level-1"]


### PR DESCRIPTION
…ipts

I came up with this hare-brained idea to roll my own parameterization scheme. The inputs to the test cases go in the docstring. Then a fixture handles all the business logic and returns the result.

I really like how this turned out. It has all the benefits of using `pytest.mark.parametrize`, without the pitfalls. Namely, there's no need for dangling assertion functions that live separately from the test inputs.