### PR TITLE
refactor: move taskcluster root url definitions to their own file

### DIFF
--- a/taskcluster/fxci_config_taskgraph/transforms/firefoxci_artifact.py
+++ b/taskcluster/fxci_config_taskgraph/transforms/firefoxci_artifact.py
@@ -9,10 +9,8 @@ from copy import deepcopy
 
 from taskgraph.transforms.base import TransformSequence
 
-from fxci_config_taskgraph.util.integration import (
-    STAGING_ROOT_URL,
-    find_tasks,
-)
+from fxci_config_taskgraph.util.constants import STAGING_ROOT_URL
+from fxci_config_taskgraph.util.integration import find_tasks
 
 transforms = TransformSequence()
 

--- a/taskcluster/fxci_config_taskgraph/transforms/integration_test.py
+++ b/taskcluster/fxci_config_taskgraph/transforms/integration_test.py
@@ -9,12 +9,8 @@ from typing import Any
 
 from taskgraph.transforms.base import TransformSequence
 
-from fxci_config_taskgraph.util.integration import (
-    FIREFOXCI_ROOT_URL,
-    STAGING_ROOT_URL,
-    find_tasks,
-    get_taskcluster_client,
-)
+from fxci_config_taskgraph.util.constants import FIREFOXCI_ROOT_URL, STAGING_ROOT_URL
+from fxci_config_taskgraph.util.integration import find_tasks, get_taskcluster_client
 
 transforms = TransformSequence()
 

--- a/taskcluster/fxci_config_taskgraph/util/constants.py
+++ b/taskcluster/fxci_config_taskgraph/util/constants.py
@@ -1,0 +1,2 @@
+FIREFOXCI_ROOT_URL = "https://firefox-ci-tc.services.mozilla.com"
+STAGING_ROOT_URL = "https://stage.taskcluster.nonprod.cloudops.mozgcp.net"

--- a/taskcluster/fxci_config_taskgraph/util/integration.py
+++ b/taskcluster/fxci_config_taskgraph/util/integration.py
@@ -8,8 +8,7 @@ from typing import Any
 import requests
 import taskcluster
 
-FIREFOXCI_ROOT_URL = "https://firefox-ci-tc.services.mozilla.com"
-STAGING_ROOT_URL = "https://stage.taskcluster.nonprod.cloudops.mozgcp.net"
+from fxci_config_taskgraph.util.constants import FIREFOXCI_ROOT_URL
 
 
 @cache

--- a/taskcluster/scripts/fetch-firefoxci-artifacts.py
+++ b/taskcluster/scripts/fetch-firefoxci-artifacts.py
@@ -8,7 +8,7 @@ import os
 import requests
 import taskcluster
 
-from fxci_config_taskgraph.util.integration import FIREFOXCI_ROOT_URL, STAGING_ROOT_URL
+from fxci_config_taskgraph.util.constants import FIREFOXCI_ROOT_URL, STAGING_ROOT_URL
 
 
 def get_firefoxci_credentials() -> dict[str, str]:

--- a/taskcluster/test/test_transforms_firefoxci_artifact.py
+++ b/taskcluster/test/test_transforms_firefoxci_artifact.py
@@ -10,11 +10,8 @@ from taskgraph.util.copy import deepcopy
 from taskgraph.util.templates import merge
 
 from fxci_config_taskgraph.transforms.firefoxci_artifact import transforms
-from fxci_config_taskgraph.util.integration import (
-    FIREFOXCI_ROOT_URL,
-    STAGING_ROOT_URL,
-    find_tasks,
-)
+from fxci_config_taskgraph.util.constants import FIREFOXCI_ROOT_URL, STAGING_ROOT_URL
+from fxci_config_taskgraph.util.integration import find_tasks
 
 
 @pytest.fixture

--- a/taskcluster/test/test_transforms_integration_test.py
+++ b/taskcluster/test/test_transforms_integration_test.py
@@ -10,11 +10,8 @@ from taskgraph.util.copy import deepcopy
 from taskgraph.util.templates import merge
 
 from fxci_config_taskgraph.transforms.integration_test import transforms
-from fxci_config_taskgraph.util.integration import (
-    FIREFOXCI_ROOT_URL,
-    STAGING_ROOT_URL,
-    find_tasks,
-)
+from fxci_config_taskgraph.util.constants import FIREFOXCI_ROOT_URL, STAGING_ROOT_URL
+from fxci_config_taskgraph.util.integration import find_tasks
 
 
 @pytest.fixture


### PR DESCRIPTION
This allows them to be imported without depending on any of the imports that `util/integration.py` does. (This is going to become a problem in https://github.com/mozilla-releng/fxci-config/pull/210, when I'm adding a `taskgraph` import there.)