### PR TITLE
ci: install ci-admin in Decision tasks

### DIFF
--- a/taskcluster/fxci_config_taskgraph/optimizations.py
+++ b/taskcluster/fxci_config_taskgraph/optimizations.py
@@ -13,6 +13,11 @@ class IntegrationTestStrategy(OptimizationStrategy):
     @cache
     def _get_modified_worker_pools(self) -> set[str]:
         cmd = [
+            "uv",
+            "tool",
+            "run",
+            "--with",
+            os.getcwd(),
             "tc-admin",
             "diff",
             "--environment",


### PR DESCRIPTION
This fixes an issue when running the integration-test optimization.