### PR TITLE
feat: add cron hooks for translations pipeline run

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -1204,11 +1204,16 @@ translations:
     github-pull-request:
       policy: public
     taskgraph-actions: true
+    taskgraph-cron: true
     trust-domain-scopes: true
     treeherder-reporting: true
     pr-actions: true
     beetmover: true
     scriptworker: true
+  cron:
+    notify_emails: []
+    targets:
+      - run-pipeline
 
 # Bug 1822403: Add taskgraph support to firefox-translations-training
 # TODO: this should be either a different trust domain or level before
@@ -1225,10 +1230,15 @@ staging-firefox-translations-training:
     github-pull-request:
       policy: public
     taskgraph-actions: true
+    taskgraph-cron: true
     trust-domain-scopes: true
     treeherder-reporting: true
     pr-actions: true
     beetmover: true
+  cron:
+    notify_emails: []
+    targets:
+      - run-pipeline
 
 # Bug 1822403: Enable the profiler repository on taskcluster
 firefox-profiler:


### PR DESCRIPTION
This is in support of https://bugzilla.mozilla.org/show_bug.cgi?id=1937882, where we'll be adding translations integration tests. A patch for https://github.com/mozilla/translations will follow.