### PR TITLE
ciadmin: stub out tcadmin.current.clients.fetch_clients if we're not …

### DIFF
--- a/src/ciadmin/boot.py
+++ b/src/ciadmin/boot.py
@@ -79,6 +79,11 @@ def boot():
                     appconfig.generators.register(resource_module)
                 else:
                     click.echo(f"Ignoring invalid resource: {reso}.")
+            if "clients" not in resources_list:
+                from tcadmin.current import clients
+                async def fetch_clients(resources):
+                    return
+                clients.fetch_clients = fetch_clients
 
         # Remove the --resources arguments from sys.argv so inner "click.command"s don't complain
         if "--resources" in sys.argv:

--- a/src/ciadmin/boot.py
+++ b/src/ciadmin/boot.py
@@ -81,8 +81,10 @@ def boot():
                     click.echo(f"Ignoring invalid resource: {reso}.")
             if "clients" not in resources_list:
                 from tcadmin.current import clients
+
                 async def fetch_clients(resources):
                     return
+
                 clients.fetch_clients = fetch_clients
 
         # Remove the --resources arguments from sys.argv so inner "click.command"s don't complain


### PR DESCRIPTION
…interested

fetch_clients requires the auth:list-clients scope, which anonymous clients don't have.  So if we're only interested in other resource types, we can skip fetching clients and avoid returning an error.