### PR TITLE
ci: don't hide tc-admin stderr

### DIFF
--- a/taskcluster/fxci_config_taskgraph/optimizations.py
+++ b/taskcluster/fxci_config_taskgraph/optimizations.py
@@ -28,7 +28,7 @@ class IntegrationTestStrategy(OptimizationStrategy):
         ]
         env = os.environ.copy()
         env["TASKCLUSTER_ROOT_URL"] = FIREFOXCI_ROOT_URL
-        proc = subprocess.run(cmd, capture_output=True, text=True, env=env)
+        proc = subprocess.run(cmd, stdout=subprocess.PIPE, text=True, env=env)
         lines = [line for line in proc.stdout.splitlines() if line.startswith("!")]
 
         worker_pools = set()


### PR DESCRIPTION
tc-admin diff uses the same exit code (1) both for "there was an error" and "I found differences", so its error output is basically the only way we can differentiate currently.