### PR TITLE
lower queue inactivity timeout for expensive translations workers

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -489,6 +489,9 @@ pools:
         trusted: fxci-level3-gcp
         default: fxci-level1-gcp
     config:
+      lifecycle:
+        # low inactivity timeout because these workers are very expensive
+        queueInactivityTimeout: 300
       worker-config:
         genericWorker:
           config:
@@ -549,6 +552,9 @@ pools:
         trusted: fxci-level3-gcp
         default: fxci-level1-gcp
     config:
+      lifecycle:
+        # low inactivity timeout because these workers are very expensive
+        queueInactivityTimeout: 300
       worker-config:
         genericWorker:
           config:
@@ -581,6 +587,9 @@ pools:
         trusted: fxci-level3-gcp
         default: fxci-level1-gcp
     config:
+      lifecycle:
+        # low inactivity timeout because these workers are very expensive
+        queueInactivityTimeout: 300
       worker-config:
         genericWorker:
           config:
@@ -614,6 +623,9 @@ pools:
         trusted: fxci-level3-gcp
         default: fxci-level1-gcp
     config:
+      lifecycle:
+        # low inactivity timeout because these workers are very expensive
+        queueInactivityTimeout: 300
       worker-config:
         genericWorker:
           config:
@@ -646,6 +658,9 @@ pools:
         trusted: fxci-level3-gcp
         default: fxci-level1-gcp
     config:
+      lifecycle:
+        # low inactivity timeout because these workers are very expensive
+        queueInactivityTimeout: 300
       worker-config:
         genericWorker:
           config:
@@ -679,6 +694,9 @@ pools:
         trusted: fxci-level3-gcp
         default: fxci-level1-gcp
     config:
+      lifecycle:
+        # low inactivity timeout because these workers are very expensive
+        queueInactivityTimeout: 300
       minCapacity: 0
       maxCapacity: 1000
       regions: [us-central1, us-west1]
@@ -703,6 +721,9 @@ pools:
         trusted: fxci-level3-gcp
         default: fxci-level1-gcp
     config:
+      lifecycle:
+        # low inactivity timeout because these workers are very expensive
+        queueInactivityTimeout: 300
       minCapacity: 0
       maxCapacity: 16
       regions: [us-central1, us-west1]
@@ -728,6 +749,9 @@ pools:
         trusted: fxci-level3-gcp
         default: fxci-level1-gcp
     config:
+      lifecycle:
+        # low inactivity timeout because these workers are very expensive
+        queueInactivityTimeout: 300
       minCapacity: 0
       maxCapacity: 1000
       regions: [us-central1, us-west1]
@@ -752,6 +776,9 @@ pools:
         trusted: fxci-level3-gcp
         default: fxci-level1-gcp
     config:
+      lifecycle:
+        # low inactivity timeout because these workers are very expensive
+        queueInactivityTimeout: 300
       minCapacity: 0
       maxCapacity: 8
       regions: [us-central1, us-west1]
@@ -777,6 +804,9 @@ pools:
         trusted: fxci-level3-gcp
         default: fxci-level1-gcp
     config:
+      lifecycle:
+        # low inactivity timeout because these workers are very expensive
+        queueInactivityTimeout: 300
       minCapacity: 0
       maxCapacity: 1000
       regions: [us-central1, us-west1]
@@ -1758,6 +1788,9 @@ pools:
         trusted: fxci-level3-gcp
         default: fxci-level1-gcp
     config:
+      lifecycle:
+        # low inactivity timeout because these workers are very expensive
+        queueInactivityTimeout: 300
       worker-config:
         genericWorker:
           config:
@@ -1789,6 +1822,9 @@ pools:
         trusted: fxci-level3-gcp
         default: fxci-level1-gcp
     config:
+      lifecycle:
+        # low inactivity timeout because these workers are very expensive
+        queueInactivityTimeout: 300
       worker-config:
         genericWorker:
           config:
@@ -1823,6 +1859,9 @@ pools:
         trusted: fxci-level3-gcp
         default: fxci-level1-gcp
     config:
+      lifecycle:
+        # low inactivity timeout because these workers are very expensive
+        queueInactivityTimeout: 300
       worker-config:
         genericWorker:
           config:
@@ -1858,6 +1897,9 @@ pools:
         trusted: fxci-level3-gcp
         default: fxci-level1-gcp
     config:
+      lifecycle:
+        # low inactivity timeout because these workers are very expensive
+        queueInactivityTimeout: 300
       worker-config:
         genericWorker:
           config:
@@ -1891,6 +1933,9 @@ pools:
         trusted: fxci-level3-gcp
         default: fxci-level1-gcp
     config:
+      lifecycle:
+        # low inactivity timeout because these workers are very expensive
+        queueInactivityTimeout: 300
       worker-config:
         genericWorker:
           config:
@@ -1924,6 +1969,9 @@ pools:
         trusted: fxci-level3-gcp
         default: fxci-level1-gcp
     config:
+      lifecycle:
+        # low inactivity timeout because these workers are very expensive
+        queueInactivityTimeout: 300
       worker-config:
         genericWorker:
           config:
@@ -1959,6 +2007,9 @@ pools:
         trusted: fxci-level3-gcp
         default: fxci-level1-gcp
     config:
+      lifecycle:
+        # low inactivity timeout because these workers are very expensive
+        queueInactivityTimeout: 300
       worker-config:
         genericWorker:
           config:
@@ -1994,6 +2045,9 @@ pools:
         trusted: fxci-level3-gcp
         default: fxci-level1-gcp
     config:
+      lifecycle:
+        # low inactivity timeout because these workers are very expensive
+        queueInactivityTimeout: 300
       worker-config:
         genericWorker:
           config:
@@ -2034,6 +2088,9 @@ pools:
         trusted: fxci-level3-gcp
         default: fxci-level1-gcp
     config:
+      lifecycle:
+        # low inactivity timeout because these workers are very expensive
+        queueInactivityTimeout: 300
       worker-config:
         genericWorker:
           config:


### PR DESCRIPTION
These currently use the default 2 hours, which is very wasteful. 5 minutes ought to be enough for them to reboot and claim another task, if it's available immediately.