### PR TITLE
RELOPS-1188: add 22.04 image with gnome-keyring fix, use in test pool

### DIFF
--- a/worker-images.yml
+++ b/worker-images.yml
@@ -38,9 +38,6 @@ monopacker-docker-worker-relops528: monopacker-docker-worker-2023-04-13-relops52
 monopacker-gw-gcp-wayland-gui-relops1188:
   fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-gui-googlecompute-2025-01-09t22-53-49z
   fxci-level3-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-gui-googlecompute-2025-01-09t22-53-49z
-monopacker-gw-gcp-wayland-gui-relops1071:
-  fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-gui-googlecompute-2024-08-22t22-48-09z
-  fxci-level3-gcp: projects/fxci-production-level3-workers/global/images/gw-fxci-gcp-l3-gui-googlecompute-2024-09-18t05-46-31z
 monopacker-gw-gcp-wayland-gui-arm64-relops1071:
   fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-arm64-gui-googlecompute-2024-09-18t14-57-52z
   fxci-level3-gcp: projects/fxci-production-level3-workers/global/images/gw-fxci-gcp-l3-arm64-gui-googlecompute-2024-09-18t19-02-58z

--- a/worker-images.yml
+++ b/worker-images.yml
@@ -34,6 +34,9 @@ monopacker-docker-worker-gcp-current: handbuilt-docker-worker-tester-20240614
 
 # 'image qualification' pool aliases
 monopacker-docker-worker-relops528: monopacker-docker-worker-2023-04-13-relops528
+# testing gnome-keyring fixes (https://mozilla-hub.atlassian.net/browse/RELOPS-1188)
+monopacker-gw-gcp-wayland-gui-relops1188:
+  fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-gui-googlecompute-2025-01-09t22-53-49z
 monopacker-gw-gcp-wayland-gui-relops1071:
   fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-gui-googlecompute-2024-08-22t22-48-09z
   fxci-level3-gcp: projects/fxci-production-level3-workers/global/images/gw-fxci-gcp-l3-gui-googlecompute-2024-09-18t05-46-31z

--- a/worker-images.yml
+++ b/worker-images.yml
@@ -37,6 +37,7 @@ monopacker-docker-worker-relops528: monopacker-docker-worker-2023-04-13-relops52
 # testing gnome-keyring fixes (https://mozilla-hub.atlassian.net/browse/RELOPS-1188)
 monopacker-gw-gcp-wayland-gui-relops1188:
   fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-gui-googlecompute-2025-01-09t22-53-49z
+  fxci-level3-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-gui-googlecompute-2025-01-09t22-53-49z
 monopacker-gw-gcp-wayland-gui-relops1071:
   fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-gui-googlecompute-2024-08-22t22-48-09z
   fxci-level3-gcp: projects/fxci-production-level3-workers/global/images/gw-fxci-gcp-l3-gui-googlecompute-2024-09-18t05-46-31z

--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -1567,7 +1567,7 @@ pools:
       maxCapacity: 10
       implementation: generic-worker/worker-runner-linux-multi
       regions: [us-central1, us-west1]
-      image: monopacker-gw-gcp-wayland-gui-relops1071
+      image: monopacker-gw-gcp-wayland-gui-relops1188
       security:
         by-chain-of-trust:
           trusted: trusted


### PR DESCRIPTION
Use a new Ubuntu 22.04 image with a fix for gnome-keyring locking issues.

Based on https://github.com/mozilla-platform-ops/monopacker/pull/153.

see https://mozilla-hub.atlassian.net/browse/RELOPS-1188
