### PR TITLE
use latest image for monopacker-gw-gcp-wayland-gui-relops1188 alias

### DIFF
--- a/worker-images.yml
+++ b/worker-images.yml
@@ -36,8 +36,8 @@ monopacker-docker-worker-gcp-current: handbuilt-docker-worker-tester-20240614
 monopacker-docker-worker-relops528: monopacker-docker-worker-2023-04-13-relops528
 # testing gnome-keyring fixes (https://mozilla-hub.atlassian.net/browse/RELOPS-1188)
 monopacker-gw-gcp-wayland-gui-relops1188:
-  fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-gui-googlecompute-2025-01-09t22-53-49z
-  fxci-level3-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-gui-googlecompute-2025-01-09t22-53-49z
+  fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-gui-googlecompute-2025-01-13t22-33-40z
+  fxci-level3-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-gui-googlecompute-2025-01-13t22-33-40z
 monopacker-gw-gcp-wayland-gui-arm64-relops1071:
   fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-arm64-gui-googlecompute-2024-09-18t14-57-52z
   fxci-level3-gcp: projects/fxci-production-level3-workers/global/images/gw-fxci-gcp-l3-arm64-gui-googlecompute-2024-09-18t19-02-58z


### PR DESCRIPTION
Update image alias to use the latest image built from https://github.com/mozilla-platform-ops/monopacker/pull/153.

See https://mozilla-hub.atlassian.net/browse/RELOPS-1188.