### PR TITLE
fix: add cron hook for staging application services nightly

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -773,6 +773,8 @@ staging-application-services:
     taskgraph-actions: true
     trust-domain-scopes: true
     beetmover: true
+  cron:
+    targets: [nightly]
 
 glean:
   repo: https://github.com/mozilla/glean


### PR DESCRIPTION
This will allow testing autograph signing in the staging repo more easily (signing only runs on cron or release tasks in this repo).