### PR TITLE
deploy tc 77.3.1 to win2022 l1 builder & bump image version to 1.0.1

### DIFF
--- a/worker-images.yml
+++ b/worker-images.yml
@@ -171,9 +171,9 @@ ronin_b1_windows2022_64_2009_alpha:
     name: win2022_64_2009_alpha
 ronin_b1_windows2022_64_2009:
   azure2:
-    version: 1.0.0
+    version: 1.0.1
     resource_group: rg-packer-worker-images
-    deployment_id: "8346140"
+    deployment_id: "189d045"
     name: win2022_64_2009
 ronin-b3-windows2022-prod:
   azure_trusted:


### PR DESCRIPTION
Here's the win2022 L1 Alpha pool with a [green ](https://treeherder.mozilla.org/jobs?repo=try&revision=c1233b07f0605dcddb18f72519bebc92184ca880) try push

Tracking in [RELOPS-1238](https://mozilla-hub.atlassian.net/browse/RELOPS-1238)

Sbom located [here](https://github.com/mozilla-platform-ops/worker-images/blob/main/sboms/win2022-64-2009-1.0.1.md)