### PR TITLE
chore: remove `containerEngine` config

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -400,7 +400,6 @@ pools:
             enableInteractive: true
             d2gConfig:
               enableD2G: true
-              containerEngine: docker
             headlessTasks: true
             ed25519SigningKeyLocation: '/etc/generic-worker/ed25519_key'
       minCapacity: 0
@@ -433,7 +432,6 @@ pools:
             enableInteractive: true
             d2gConfig:
               enableD2G: true
-              containerEngine: docker
             headlessTasks: true
             ed25519SigningKeyLocation: '/etc/generic-worker/ed25519_key'
       minCapacity: 0
@@ -466,7 +464,6 @@ pools:
             enableInteractive: true
             d2gConfig:
               enableD2G: true
-              containerEngine: docker
             headlessTasks: true
             ed25519SigningKeyLocation: '/etc/generic-worker/ed25519_key'
       minCapacity: 0
@@ -500,7 +497,6 @@ pools:
             enableInteractive: true
             d2gConfig:
               enableD2G: true
-              containerEngine: docker
             headlessTasks: true
             ed25519SigningKeyLocation: '/etc/generic-worker/ed25519_key'
       minCapacity: 0
@@ -561,7 +557,6 @@ pools:
             enableInteractive: true
             d2gConfig:
               enableD2G: true
-              containerEngine: docker
             headlessTasks: true
             ed25519SigningKeyLocation: '/etc/generic-worker/ed25519_key'
       minCapacity: 0
@@ -594,7 +589,6 @@ pools:
             enableInteractive: true
             d2gConfig:
               enableD2G: true
-              containerEngine: docker
             headlessTasks: true
             ed25519SigningKeyLocation: '/etc/generic-worker/ed25519_key'
       minCapacity: 0
@@ -628,7 +622,6 @@ pools:
             enableInteractive: true
             d2gConfig:
               enableD2G: true
-              containerEngine: docker
             headlessTasks: true
             ed25519SigningKeyLocation: '/etc/generic-worker/ed25519_key'
       minCapacity: 0
@@ -661,7 +654,6 @@ pools:
             enableInteractive: true
             d2gConfig:
               enableD2G: true
-              containerEngine: docker
             headlessTasks: true
             ed25519SigningKeyLocation: '/etc/generic-worker/ed25519_key'
       minCapacity: 0
@@ -1676,7 +1668,6 @@ pools:
             ed25519SigningKeyLocation: '/etc/generic-worker/ed25519_key'
             d2gConfig:
               enableD2G: true
-              containerEngine: docker
             enableInteractive: true
       minCapacity: 0
       maxCapacity: 100
@@ -1703,7 +1694,6 @@ pools:
             ed25519SigningKeyLocation: '/etc/generic-worker/ed25519_key'
             d2gConfig:
               enableD2G: true
-              containerEngine: docker
             enableInteractive: true
       minCapacity: 0
       maxCapacity: 100
@@ -2016,7 +2006,6 @@ pools:
             d2gConfig:
               enableD2G: true
               allowGPUs: true
-              containerEngine: docker
             headlessTasks: true
             ed25519SigningKeyLocation: '/etc/generic-worker/ed25519_key'
       minCapacity: 0
@@ -2056,7 +2045,6 @@ pools:
             d2gConfig:
               enableD2G: true
               allowGPUs: true
-              containerEngine: docker
             headlessTasks: true
             ed25519SigningKeyLocation: '/etc/generic-worker/ed25519_key'
       minCapacity: 0


### PR DESCRIPTION
Generic Worker's config `d2gConfig.containerEngine` will be removed soon with https://github.com/taskcluster/taskcluster/pull/7482.

This change is safe to land now, as `docker` is the default, anyway.