### PR TITLE
Use Phabricator build target PHID when triggering code-review hook

### DIFF
--- a/hooks.yml
+++ b/hooks.yml
@@ -148,30 +148,10 @@ project-relman/code-review-testing:
     additionalProperties: true
     properties:
 
-      # Trigger hook with token payload to create a try push
-      object:
-        type: object
-        required:
-          - type
-          - phid
-        properties:
-          type:
-            type: string
-            description: Phabricator object's type triggering the hook
-          phid:
-            type: string
-            description: Phabricator object's PHID triggering the hook
-      transactions:
-        type: array
-        description: Phabricator transactions leading to this trigger
-        items:
-          type: object
-          required:
-            - phid
-          properties:
-            phid:
-              type: string
-              description: Phabricator transaction's PHID
+      # Trigger hook from Phabricator with token payload to create a try push
+      build_target_phid:
+        type: string
+        description: Phabricator Build target's PHID triggering the hook
 
       # Trigger hook from pulse for analyzing results
       runId:

--- a/hooks/project-relman/code-review-testing.yml
+++ b/hooks/project-relman/code-review-testing.yml
@@ -34,16 +34,8 @@ payload:
       - $if: firedBy == 'triggerHookWithToken'
         else: {}
         then:
-          $let:
-            transactions:
-              $map: {$eval: payload.transactions}
-              each(transaction): {$eval: transaction.phid}
-          in:
-            PHABRICATOR_OBJECT_TYPE:
-              $eval: payload.object.type
-            PHABRICATOR_OBJECT_PHID:
-              $eval: payload.object.phid
-            PHABRICATOR_TRANSACTIONS: {$json: {$eval: transactions}}
+          PHABRICATOR_BUILD_TARGET:
+            $eval: payload.build_target_phid
       - $if: firedBy == 'pulseMessage'
         else: {}
         then:


### PR DESCRIPTION
This PR simplifies the payload required to trigger the hook with a token, as Phabricator will now directly call `triggerHookWithToken` and provides the build target PHID (instead of the webhook trigger payload).

The build plan is pending deployment on phabricator-dev: https://bugzilla.mozilla.org/show_bug.cgi?id=1935142#c24

A PR is also pending review on the bot to support the new environment variable https://github.com/mozilla/code-review/pull/2611/