### PR TITLE
[RELOPS-773] Provision new Mac Signers

### DIFF
--- a/clients.yml
+++ b/clients.yml
@@ -896,6 +896,14 @@ project/releng/scriptworker/v2/mac-signing/prod/firefoxci-mozillavpn-t:
     # TODO: Remove once mac-signing19 is not being used for VPN anymore
     - assume:worker-type:scriptworker-prov-v1/mozillavpn-t-signing-mac
     - queue:worker-id:mozillavpn-t-signing-mac/vpn-mac-v3-signing*
+project/releng/scriptworker/v2/mac-signing/prod/firefoxci-ff-mac14-prod:
+  description: firefox prod signing on macOS14
+  scopes:
+    - assume:worker-type:scriptworker-prov-v1/vpn-depsigning-mac-v1
+    - queue:worker-id:vpn-depsigning-mac-v1/dep-mac-v3-signing*
+    # TODO: Remove once mac-signing19 is not being used for VPN anymore
+    - assume:worker-type:scriptworker-prov-v1/mozillavpn-t-signing-mac
+    - queue:worker-id:mozillavpn-t-signing-mac/vpn-mac-v3-signing*
 project/releng/scriptworker/v2/mac-signing/prod/firefoxci-mozillavpn-3:
   description: mozillavpn mac signing
   scopes:

--- a/clients.yml
+++ b/clients.yml
@@ -873,6 +873,11 @@ project/releng/scriptworker/v2/iscript/tb-prod:
   scopes:
     - assume:worker-type:scriptworker-prov-v1/tb-signing-mac-v1
     - queue:worker-id:signing-mac-v1/tb-mac-v3-signing*
+project/releng/scriptworker/v2/mac-signing/prod/firefoxci-gecko-signing-mac14m2-dep:
+  description: Dep signing worker pool for Firefox on macOS 14 (M2). Handles macOS-specific signing tasks.
+  scopes:
+    - assume:worker-type:scriptworker-prov-v1/gecko-signing-mac14m2-prod
+    - queue:worker-id:gecko-signing-mac14m2-prod/signing-mac14m2-prod*
 project/releng/scriptworker/v2/mac-signing/prod/firefoxci-gecko-signing-mac14m2:
   description: Production signing worker pool for Firefox on macOS 14 (M2). Handles macOS-specific signing tasks.
   scopes:

--- a/clients.yml
+++ b/clients.yml
@@ -873,16 +873,16 @@ project/releng/scriptworker/v2/iscript/tb-prod:
   scopes:
     - assume:worker-type:scriptworker-prov-v1/tb-signing-mac-v1
     - queue:worker-id:signing-mac-v1/tb-mac-v3-signing*
-project/releng/scriptworker/v2/mac-signing/prod/firefoxci-gecko-signing-mac14m2-dep:
+project/releng/scriptworker/v2/mac-signing/dev/firefoxci-gecko-t:
   description: Dep signing worker pool for Firefox on macOS 14 (M2). Handles macOS-specific signing tasks.
   scopes:
-    - assume:worker-type:scriptworker-prov-v1/gecko-signing-mac14m2-prod
-    - queue:worker-id:gecko-signing-mac14m2-prod/signing-mac14m2-prod*
-project/releng/scriptworker/v2/mac-signing/prod/firefoxci-gecko-signing-mac14m2:
+    - assume:worker-type:scriptworker-prov-v1/gecko-depsigning-mac14m2
+    - queue:worker-id:gecko-depsigning-mac14m2/depsigning-mac14m2*
+project/releng/scriptworker/v2/mac-signing/prod/firefoxci-gecko-3:
   description: Production signing worker pool for Firefox on macOS 14 (M2). Handles macOS-specific signing tasks.
   scopes:
-    - assume:worker-type:scriptworker-prov-v1/gecko-signing-mac14m2-prod
-    - queue:worker-id:gecko-signing-mac14m2-prod/signing-mac14m2-prod*
+    - assume:worker-type:scriptworker-prov-v1/gecko-signing-mac14m2
+    - queue:worker-id:gecko-signing-mac14m2/signing-mac14m2*
 project/releng/scriptworker/v2/signing/dev/firefoxci-mozillavpn-t:
   description: mozillavpn linux signing
   scopes:

--- a/clients.yml
+++ b/clients.yml
@@ -873,6 +873,11 @@ project/releng/scriptworker/v2/iscript/tb-prod:
   scopes:
     - assume:worker-type:scriptworker-prov-v1/tb-signing-mac-v1
     - queue:worker-id:signing-mac-v1/tb-mac-v3-signing*
+project/releng/scriptworker/v2/mac-signing/prod/firefoxci-gecko-signing-mac14m2-prod:
+  description: Production signing worker pool for Firefox on macOS 14 (M2). Handles macOS-specific signing tasks.
+  scopes:
+    - assume:worker-type:scriptworker-prov-v1/gecko-signing-mac14m2-prod
+    - queue:worker-id:gecko-signing-mac14m2-prod/signing-mac14m2-prod*
 project/releng/scriptworker/v2/signing/dev/firefoxci-mozillavpn-t:
   description: mozillavpn linux signing
   scopes:
@@ -896,11 +901,6 @@ project/releng/scriptworker/v2/mac-signing/prod/firefoxci-mozillavpn-t:
     # TODO: Remove once mac-signing19 is not being used for VPN anymore
     - assume:worker-type:scriptworker-prov-v1/mozillavpn-t-signing-mac
     - queue:worker-id:mozillavpn-t-signing-mac/vpn-mac-v3-signing*
-project/releng/scriptworker/v2/mac-signing/prod/firefoxci-ff-mac14m2-prod:
-  description: firefox prod signing on M2 macOS14
-  scopes:
-    - assume:worker-type:scriptworker-prov-v1/gecko-depsigning-mac14m2
-    - queue:worker-id:gecko-depsigning-mac14m2/dep-mac14m2-signing*
 project/releng/scriptworker/v2/mac-signing/prod/firefoxci-mozillavpn-3:
   description: mozillavpn mac signing
   scopes:

--- a/clients.yml
+++ b/clients.yml
@@ -873,7 +873,7 @@ project/releng/scriptworker/v2/iscript/tb-prod:
   scopes:
     - assume:worker-type:scriptworker-prov-v1/tb-signing-mac-v1
     - queue:worker-id:signing-mac-v1/tb-mac-v3-signing*
-project/releng/scriptworker/v2/mac-signing/prod/firefoxci-gecko-signing-mac14m2-prod:
+project/releng/scriptworker/v2/mac-signing/prod/firefoxci-gecko-signing-mac14m2:
   description: Production signing worker pool for Firefox on macOS 14 (M2). Handles macOS-specific signing tasks.
   scopes:
     - assume:worker-type:scriptworker-prov-v1/gecko-signing-mac14m2-prod

--- a/clients.yml
+++ b/clients.yml
@@ -896,14 +896,11 @@ project/releng/scriptworker/v2/mac-signing/prod/firefoxci-mozillavpn-t:
     # TODO: Remove once mac-signing19 is not being used for VPN anymore
     - assume:worker-type:scriptworker-prov-v1/mozillavpn-t-signing-mac
     - queue:worker-id:mozillavpn-t-signing-mac/vpn-mac-v3-signing*
-project/releng/scriptworker/v2/mac-signing/prod/firefoxci-ff-mac14-prod:
-  description: firefox prod signing on macOS14
+project/releng/scriptworker/v2/mac-signing/prod/firefoxci-ff-mac14m2-prod:
+  description: firefox prod signing on M2 macOS14
   scopes:
-    - assume:worker-type:scriptworker-prov-v1/vpn-depsigning-mac-v1
-    - queue:worker-id:vpn-depsigning-mac-v1/dep-mac-v3-signing*
-    # TODO: Remove once mac-signing19 is not being used for VPN anymore
-    - assume:worker-type:scriptworker-prov-v1/mozillavpn-t-signing-mac
-    - queue:worker-id:mozillavpn-t-signing-mac/vpn-mac-v3-signing*
+    - assume:worker-type:scriptworker-prov-v1/gecko-depsigning-mac14m2
+    - queue:worker-id:gecko-depsigning-mac14m2/dep-mac14m2-signing*
 project/releng/scriptworker/v2/mac-signing/prod/firefoxci-mozillavpn-3:
   description: mozillavpn mac signing
   scopes:


### PR DESCRIPTION
I’m familiar with creating worker pools like this:

```
project/releng/generic-worker/datacenter-gecko-t-osx-1400-r8:
  description: Datacenter MacOS dedicated developer and automation worker.
  scopes:
    - assume:worker-type:releng-hardware/gecko-t-osx*
    - queue:worker-id:mdc1/mac*
```
However, setting up the new Mac hardware signing machines is a bit more of a mystery to me.

For reference, the current M2 Mac signing hardware designated for this purpose is named something like this (though this can change)

`macmini-m2-44.test.releng.mdc1.mozilla.com`

The goal—perhaps obvious—is to spin up a new Firefox production signing pool on ARM/macOS 14.

Would love any feedback or insights! 😊

Existing signer [pools](https://firefox-ci-tc.services.mozilla.com/provisioners/scriptworker-prov-v1/worker-types/) for reference