### PR TITLE
update 2022 alpha builder to lower cost regions

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -2171,7 +2171,7 @@ pools:
       implementation: generic-worker/worker-runner-windows
       locations:
         by-pool-group:
-          .*-3: [east-us, central-us, east-us-2, west-us-2]
+          .*-3: [central-us, east-us-2, west-us-2]
           default: [central-us, north-central-us, east-us-2, west-us-2]
       maxCapacity:
         by-pool-group:


### PR DESCRIPTION
switch to west-us-3 to test hgclonebundles in azure
switch to lower cost region(s) 

Tracking in https://mozilla-hub.atlassian.net/browse/RELOPS-1285