### PR TITLE
feat: add lando scriptworker client for dev

### DIFF
--- a/clients-interpreted.yml
+++ b/clients-interpreted.yml
@@ -174,3 +174,15 @@
       - project:
             level: 3
             feature: [beetmover-get-artifact-scope]
+
+# Clients for landoscript workers
+- client:
+      project/releng/scriptworker/v2/lando/dev/firefoxci-{trust_domain}-1:
+          description: "{trust_domain} level 1 nonprod lando scriptworker"
+          scopes:
+              - queue:claim-work:scriptworker-k8s/{trust_domain}-1-lando-dev
+              - queue:worker-id:{trust_domain}-1-lando-dev/{trust_domain}-1-lando-dev-*
+  for:
+      - project:
+            level: 1
+            feature: [lando]

--- a/projects.yml
+++ b/projects.yml
@@ -405,6 +405,7 @@ try:
     hg-push: true
     treeherder-reporting: true
     trust-domain-scopes: true
+    lando: true
 try-comm-central:
   repo: https://hg.mozilla.org/try-comm-central
   repo_type: hg


### PR DESCRIPTION
Note that this is getting added in `clients-interpreted.yml` for Gecko, which is something we haven't done up until now. I have mixed feelings about this as these clients are shared across multiple projects, but I _think_ having consistency in the client entries is worthwhile.