### PR TITLE
chore: pick up new ubuntu 24.04 headless image

### DIFF
--- a/worker-images.yml
+++ b/worker-images.yml
@@ -98,7 +98,7 @@ ubuntu-2404-headless-alpha:
   fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-2404-amd64-headless-googlecompute-alpha
 ubuntu-2404-headless:
   ## Headless Image for Ubuntu 24.04
-  fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-2404-amd64-headless-googlecompute-2025-01-17
+  fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-2404-amd64-headless-googlecompute-2025-02-21
 
 # Windows Server 2022
 ronin_b1_windows2022_64_2009_alpha:


### PR DESCRIPTION
The main change here is generic-worker 81.0.3, which includes interactive task improvements and chain of trust d2g fixes compared to the current image.