### PR TITLE
fix: ignore new and old names for docker image tasks in translations integration tests

### DIFF
--- a/taskcluster/kinds/firefoxci-artifact/kind.yml
+++ b/taskcluster/kinds/firefoxci-artifact/kind.yml
@@ -59,6 +59,6 @@ tasks:
       # and also because they live forever, and depend on docker images which
       # expire, which causes us to try to mirror expired docker image tasks
       # into the staging cluster
-      - ^(?!(Decision|Action|PR action|build-docker-image|fetch)).*
+      - ^(?!(Decision|Action|PR action|build-docker-image|docker-image|fetch)).*
     mirror-public-fetches:
       - ^toolchain.*

--- a/taskcluster/kinds/integration-test/kind.yml
+++ b/taskcluster/kinds/integration-test/kind.yml
@@ -41,4 +41,4 @@ tasks:
       # and also because they live forever, and depend on docker images which
       # expire, which causes us to try to mirror expired docker image tasks
       # into the staging cluster
-      - ^(?!(Decision|Action|PR action|build-docker-image|fetch)).*
+      - ^(?!(Decision|Action|PR action|build-docker-image|docker-image|fetch)).*


### PR DESCRIPTION
These tasks changed names when Translations picked up a new Taskgraph version. At the moment we're in a state where both are present in the most recent cron run (some docker images have been rebuilt, others haven't); we need to keep both in here for awhile to avoid accidentally trying to rebuild them in staging (which doesn't work, and is wasteful).

This should fix the issue with integration tests I noticed in #292.