### PR TITLE
Edit mac vm pools

### DIFF
--- a/clients.yml
+++ b/clients.yml
@@ -471,7 +471,17 @@ project/releng/generic-worker/datacenter-gecko-t-osx-1300-m2:
     - queue:worker-id:mdc2/mac*
     - queue:worker-id:mdc2/t-yosemite*
     - queue:worker-id:mdc2/t-mojave*
-project/releng/generic-worker/datacenter-gecko-t-osx-1300-m2-vms:
+project/releng/generic-worker/datacenter-gecko-t-osx-1400-m-vms:
+  description: Datacenter MacOS dedicated developer and automation worker.
+  scopes:
+    - assume:worker-type:releng-hardware/gecko-t-osx*
+    - queue:worker-id:mdc1/mac*
+    - queue:worker-id:mdc1/t-yosemite*
+    - queue:worker-id:mdc1/t-mojave*
+    - queue:worker-id:mdc2/mac*
+    - queue:worker-id:mdc2/t-yosemite*
+    - queue:worker-id:mdc2/t-mojave*
+project/releng/generic-worker/datacenter-gecko-t-osx-1500-m-vms:
   description: Datacenter MacOS dedicated developer and automation worker.
   scopes:
     - assume:worker-type:releng-hardware/gecko-t-osx*

--- a/clients.yml
+++ b/clients.yml
@@ -476,21 +476,11 @@ project/releng/generic-worker/datacenter-gecko-t-osx-1400-m-vms:
   scopes:
     - assume:worker-type:releng-hardware/gecko-t-osx*
     - queue:worker-id:mdc1/mac*
-    - queue:worker-id:mdc1/t-yosemite*
-    - queue:worker-id:mdc1/t-mojave*
-    - queue:worker-id:mdc2/mac*
-    - queue:worker-id:mdc2/t-yosemite*
-    - queue:worker-id:mdc2/t-mojave*
 project/releng/generic-worker/datacenter-gecko-t-osx-1500-m-vms:
   description: Datacenter MacOS dedicated developer and automation worker.
   scopes:
     - assume:worker-type:releng-hardware/gecko-t-osx*
     - queue:worker-id:mdc1/mac*
-    - queue:worker-id:mdc1/t-yosemite*
-    - queue:worker-id:mdc1/t-mojave*
-    - queue:worker-id:mdc2/mac*
-    - queue:worker-id:mdc2/t-yosemite*
-    - queue:worker-id:mdc2/t-mojave*
 project/releng/generic-worker/datacenter-gecko-t-osx-1300-r8:
   description: Datacenter MacOS dedicated developer and automation worker.
   scopes:
@@ -591,16 +581,6 @@ project/releng/generic-worker/datacenter-gecko-t-osx-1500-m4-staging:
   scopes:
     - assume:worker-type:releng-hardware/gecko-t-osx*
     - queue:worker-id:mdc1/mac*
-project/releng/generic-worker/datacenter-gecko-t-osx-1400-m2-vms-staging:
-  description: Datacenter MacOS dedicated developer and automation worker.
-  scopes:
-    - assume:worker-type:releng-hardware/gecko-t-osx*
-    - queue:worker-id:mdc1/mac*
-    - queue:worker-id:mdc1/t-yosemite*
-    - queue:worker-id:mdc1/t-mojave*
-    - queue:worker-id:mdc2/mac*
-    - queue:worker-id:mdc2/t-yosemite*
-    - queue:worker-id:mdc2/t-mojave*
 project/releng/generic-worker/datacenter-gecko-t-win10-64-1803-hw:
   description: Datacenter Windows 10 main production worker. Used for Talos,Raptor,
     and unittest. 1803 references the os build.


### PR DESCRIPTION
I’ve made progress in automating the signer and tester [images](https://github.com/rcurranmoz/macos-image-templates/tree/master/moz/tester), and they are now mostly functional. I’d like to set up two pools for macOS 14/15 VMs to run in. For now, I’ve removed the M2/M4 designation since these VMs are provisioned with minimal resources and may be deployed interchangeably on M2 and M4 hardware.