### PR TITLE
Edit mac vm pools

### DIFF
--- a/clients.yml
+++ b/clients.yml
@@ -480,16 +480,6 @@ project/releng/generic-worker/datacenter-gecko-t-osx-1300-m2:
     - queue:worker-id:mdc2/mac*
     - queue:worker-id:mdc2/t-yosemite*
     - queue:worker-id:mdc2/t-mojave*
-project/releng/generic-worker/datacenter-gecko-t-osx-1300-m2-vms:
-  description: Datacenter MacOS dedicated developer and automation worker.
-  scopes:
-    - assume:worker-type:releng-hardware/gecko-t-osx*
-    - queue:worker-id:mdc1/mac*
-    - queue:worker-id:mdc1/t-yosemite*
-    - queue:worker-id:mdc1/t-mojave*
-    - queue:worker-id:mdc2/mac*
-    - queue:worker-id:mdc2/t-yosemite*
-    - queue:worker-id:mdc2/t-mojave*
 project/releng/generic-worker/datacenter-gecko-t-osx-1300-r8:
   description: Datacenter MacOS dedicated developer and automation worker.
   scopes:
@@ -590,16 +580,16 @@ project/releng/generic-worker/datacenter-gecko-t-osx-1500-m4-staging:
   scopes:
     - assume:worker-type:releng-hardware/gecko-t-osx*
     - queue:worker-id:mdc1/mac*
-project/releng/generic-worker/datacenter-gecko-t-osx-1400-m2-vms-staging:
+project/releng/generic-worker/datacenter-gecko-t-osx-1400-m-vms:
   description: Datacenter MacOS dedicated developer and automation worker.
   scopes:
     - assume:worker-type:releng-hardware/gecko-t-osx*
     - queue:worker-id:mdc1/mac*
-    - queue:worker-id:mdc1/t-yosemite*
-    - queue:worker-id:mdc1/t-mojave*
-    - queue:worker-id:mdc2/mac*
-    - queue:worker-id:mdc2/t-yosemite*
-    - queue:worker-id:mdc2/t-mojave*
+project/releng/generic-worker/datacenter-gecko-t-osx-1500-m-vms:
+  description: Datacenter MacOS dedicated developer and automation worker.
+  scopes:
+    - assume:worker-type:releng-hardware/gecko-t-osx*
+    - queue:worker-id:mdc1/mac*
 project/releng/generic-worker/win11-64-24h2-hw-perf-sheriff:
   description: Tracking metric variability with performance sheriffing. Tracking in RELOPS-1288.
   scopes:


### PR DESCRIPTION
I’ve made progress in automating the signer and tester [images](https://github.com/rcurranmoz/macos-image-templates/tree/master/moz/tester), and they are now mostly functional. I’d like to set up two pools for macOS 14/15 VMs to run in. For now, I’ve removed the M2/M4 designation since these VMs are provisioned with minimal resources and may be deployed interchangeably on M2 and M4 hardware.