### PR TITLE
Use Phabricator build target PHID when triggering code-review production hook

### DIFF
--- a/hooks.yml
+++ b/hooks.yml
@@ -194,3 +194,26 @@ project-relman/code-review-production:
   trigger_schema:
     type: object
     additionalProperties: true
+    properties:
+
+      # Trigger hook from Phabricator with token payload to create a try push
+      build_target_phid:
+        type: string
+        description: Phabricator Build target's PHID triggering the hook
+
+      # Trigger hook from pulse for analyzing results
+      runId:
+        type: integer
+        description: Taskcluster Task Run ID triggering the hook (should be a Try Task run)
+      status:
+        type: object
+        required:
+          - taskId
+          - taskGroupId
+        properties:
+          taskId:
+            type: string
+            description: Taskcluster Task ID triggering the hook (should be a Try Task)
+          taskGroupId:
+            type: string
+            description: Taskcluster Task Group ID triggering the hook (should be a Try Task Group)

--- a/hooks/project-relman/code-review-production.yml
+++ b/hooks/project-relman/code-review-production.yml
@@ -31,6 +31,11 @@ payload:
         else: {}
         then:
           $eval: payload
+      - $if: firedBy == 'triggerHookWithToken'
+        else: {}
+        then:
+          PHABRICATOR_BUILD_TARGET:
+            $eval: payload.build_target_phid
       - $if: firedBy == 'pulseMessage'
         else: {}
         then:


### PR DESCRIPTION
This is the same work as #278 but for the production hook.

We want to try out the new code-review trigger system in production soon.