### PR TITLE
linux-2404-headless-ssd-alpha: move generic-worker caches/downloads t…

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -1623,6 +1623,8 @@ pools:
           config:
             enableInteractive: true
             headlessTasks: true
+            downloadsDir: /home/generic-worker/downloads
+            cachesDir: /home/generic-worker/caches
       minCapacity: 0
       maxCapacity: 10
       implementation: generic-worker/linux-d2g


### PR DESCRIPTION
…o /home

Per https://github.com/taskcluster/taskcluster/issues/7580 this needs to be under the same mount point as the tasks dir.  As an added benefit this moves them to the local ssd.