### PR TITLE
fix: make worker pool generation deterministic

### DIFF
--- a/src/ciadmin/generate/worker_pools.py
+++ b/src/ciadmin/generate/worker_pools.py
@@ -120,7 +120,7 @@ def get_aws_provider_config(
     _validate_instance_capacity(pool_id, implementation, instance_types)
 
     launch_configs = []
-    for region in regions:
+    for region in sorted(regions):
         availability_zones = evaluate_keyed_by(
             aws_config["availability-zones"], pool_id, {"region": region}
         )
@@ -129,14 +129,14 @@ def get_aws_provider_config(
             pool_id,
             {"region": region, "security": security},
         )
-        for availability_zone in availability_zones:
+        for availability_zone in sorted(availability_zones):
             subnet_id = evaluate_keyed_by(
                 aws_config["subnet-id"],
                 pool_id,
                 {"availability-zone": availability_zone},
             )
 
-            for instance_type in instance_types:
+            for instance_type in sorted(instance_types):
                 if is_invalid_aws_instance_type(
                     aws_config["invalid-instances"],
                     availability_zone,


### PR DESCRIPTION
In https://github.com/mozilla-releng/fxci-config/pull/317 we noticed some seemingly unrelated changes to worker pools in a taskgraph diff. This is almost certainly because we're not sorting regions/AZs/instance types when generating these.

It's difficult to fully verify this, but I did manage to get three identical diffs locally with this patch, and the minimal diff (ie: no additions/removals from reordering) when making a minor change to a worker pool.