### PR TITLE
Remove unused gecko-3/t-linux* pools (bug 1955562)

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -1143,9 +1143,6 @@ pools:
     variants:
       - pool-group: gecko-t
         suffix: ''
-      - pool-group: gecko-3
-        suffix: ''
-        chain-of-trust: trusted
       - pool-group: comm-t
         suffix: ''
       - pool-group: gecko-t
@@ -1155,10 +1152,7 @@ pools:
       - pool-group: nss-t
         suffix: ''
     email_on_error: true
-    provider_id:
-      by-chain-of-trust:
-        trusted: fxci-level3-gcp
-        default: fxci-level1-gcp
+    provider_id: fxci-level1-gcp
     config:
       minCapacity: 0
       maxCapacity:
@@ -1170,10 +1164,7 @@ pools:
           nss-t: 100
           comm-t: 10
       regions: [us-central1, us-west1]
-      image:
-        by-chain-of-trust:
-          trusted: monopacker-docker-worker-trusted-current-gcp
-          default: monopacker-docker-worker-gcp-current
+      image: monopacker-docker-worker-gcp-current
       instance_types:
         - minCpuPlatform: Intel Cascadelake
           disks:
@@ -1190,10 +1181,7 @@ pools:
       - pool-group: gecko-t
         suffix: -source
     email_on_error: true
-    provider_id:
-      by-chain-of-trust:
-        trusted: fxci-level3-gcp
-        default: fxci-level1-gcp
+    provider_id: fxci-level1-gcp
     config:
       minCapacity: 0
       maxCapacity:
@@ -1205,10 +1193,7 @@ pools:
           nss-t: 100
           comm-t: 10
       regions: [us-central1, us-west1]
-      image:
-        by-chain-of-trust:
-          trusted: monopacker-docker-worker-trusted-current-gcp
-          default: monopacker-docker-worker-gcp-current
+      image: monopacker-docker-worker-gcp-current
       instance_types:
         - minCpuPlatform: Intel Cascadelake
           disks:
@@ -1222,9 +1207,6 @@ pools:
     variants:
       - pool-group: gecko-t
         suffix: ''
-      - pool-group: gecko-3
-        suffix: ''
-        chain-of-trust: trusted
       - pool-group: comm-t
         suffix: ''
       - pool-group: gecko-t
@@ -1234,10 +1216,7 @@ pools:
       - pool-group: nss-t
         suffix: ''
     email_on_error: true
-    provider_id:
-      by-chain-of-trust:
-        trusted: fxci-level3-gcp
-        default: fxci-level1-gcp
+    provider_id: fxci-level1-gcp
     config:
       minCapacity: 0
       maxCapacity:
@@ -1249,10 +1228,7 @@ pools:
           nss-t: 100
           comm-t: 10
       regions: [us-central1, us-west1]
-      image:
-        by-chain-of-trust:
-          trusted: monopacker-docker-worker-trusted-current-gcp
-          default: handbuilt-docker-worker-tester-20240614
+      image: handbuilt-docker-worker-tester-20240614
       instance_types:
         - minCpuPlatform: Intel Cascadelake
           disks:
@@ -1268,10 +1244,7 @@ pools:
       - pool-group: gecko-t
         suffix: -source
     email_on_error: true
-    provider_id:
-      by-chain-of-trust:
-        trusted: fxci-level3-gcp
-        default: fxci-level1-gcp
+    provider_id: fxci-level1-gcp
     config:
       minCapacity: 0
       maxCapacity:
@@ -1283,10 +1256,7 @@ pools:
           nss-t: 100
           comm-t: 10
       regions: [us-central1, us-west1]
-      image:
-        by-chain-of-trust:
-          trusted: monopacker-docker-worker-trusted-current-gcp
-          default: handbuilt-docker-worker-tester-20240614
+      image: handbuilt-docker-worker-tester-20240614
       instance_types:
         - minCpuPlatform: Intel Cascadelake
           disks:


### PR DESCRIPTION
We moved the android x86 pgo runs to b-linux-kvm-gcp, so nothing is running there anymore.