### PR TITLE
Relops-1213: add temp Win 11 HW worker

### DIFF
--- a/clients.yml
+++ b/clients.yml
@@ -623,6 +623,10 @@ project/releng/generic-worker/win11-64-24h2-hw-alpha:
   description: Datacenter Windows 11 experimental worker. 24H2 references the os build.
   scopes:
     - assume:worker-type:releng-hardware/win11-64-24h2-hw-alpha
+project/releng/generic-worker/win11-64-24h2-hw-relops1213:
+  description: Temp Datacenter Windows 11 experimental worker for RELOPS-1213.
+  scopes:
+    - assume:worker-type:releng-hardware/win11-64-24h2-hw-relops1213
 project/releng/generic-worker/win11-64-2009-hw-ref:
   description: Datacenter Windows 11 main production worker. 2009 references the os build.
   scopes:

--- a/grants.yml
+++ b/grants.yml
@@ -268,6 +268,7 @@
     - generic-worker:os-group:gecko-t/win11-64-24h2/Administrators
     - generic-worker:os-group:gecko-t/win11-64-2009-alpha/Administrators
     - generic-worker:os-group:gecko-t/win11-64-24h2-alpha/Administrators
+    - generic-worker:os-group:gecko-t/win11-64-2009-hw-ref/Administrators
     - generic-worker:os-group:gecko-t/t-linux-2204-wayland-experimental/audio
     - generic-worker:os-group:gecko-t/t-linux-2204-wayland-experimental/video
     - generic-worker:os-group:gecko-t/t-linux-2204-wayland-snap/snap_sudo


### PR DESCRIPTION
Temp Win 11 hardware worker to test deployment features. 