### PR TITLE
deploy windows 1.0.3 image

### DIFF
--- a/worker-images.yml
+++ b/worker-images.yml
@@ -187,7 +187,7 @@ ronin_t_windows11_64_2009_alpha:
     name: win11_64_2009_alpha
 ronin_t_windows11_64_2009:
   azure2:
-    version: 1.0.2
+    version: 1.0.3
     resource_group: rg-packer-worker-images
-    deployment_id: "b1f4165"
+    deployment_id: "7769a4b"
     name: win11_64_2009


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/RELOPS-1389

Updated git to 2.49.0
updated hg to 6.9.1
Refactored mozilla build puppet code
Removed win11 sdk from aarch64 builder
Add support for win10 2009 hw pool