### PR TITLE
RELOPS-1356: add perf-a55 lambdatest client

### DIFF
--- a/clients.yml
+++ b/clients.yml
@@ -219,6 +219,15 @@ project/autophone/gecko-t-bitbar-perf-s24:
     - auth:websocktunnel-token:firefoxcitc/bitbar.*
     - queue:claim-work:proj-autophone/gecko-t-bitbar-gw-perf-s24
     - queue:worker-id:bitbar/*
+project/autophone/gecko-t-lambda-perf-a55:
+  description: Lambdatest pool for performance testing on a55
+  scopes:
+    - auth:sentry:tc-worker-script
+    - auth:statsum:tc-worker-script
+    - auth:webhooktunnel
+    - auth:websocktunnel-token:firefoxcitc/lambda.*
+    - queue:claim-work:proj-autophone/gecko-t-lambda-perf-a55
+    - queue:worker-id:lambda/*
 project/autophone/gecko-t-lambda-alpha-a55:
   description: Lambdatest pool for configuration testing on a55
   scopes:


### PR DESCRIPTION
See https://mozilla-hub.atlassian.net/browse/RELOPS-1356.

Create a production/non-testing client.