### PR TITLE
rollback arm64 windows images to 1.0.2

### DIFF
--- a/worker-images.yml
+++ b/worker-images.yml
@@ -113,22 +113,22 @@ ronin_b1_windows2022_64_2009_alpha:
     name: win2022_64_2009_alpha
 ronin_b1_windows2022_64_2009:
   azure2:
-    version: 1.0.2
+    version: 1.0.3
     resource_group: rg-packer-worker-images
-    deployment_id: "b1f4165"
+    deployment_id: "7769a4b"
     name: win2022_64_2009
 ronin_b3_windows2022_64_2009:
   azure_trusted:
-    version: 1.0.2
+    version: 1.0.3
     resource_group: rg-packer-worker-images
-    deployment_id: "b1f4165"
+    deployment_id: "7769a4b"
     name: trusted_win2022_64_2009
 # Windows 10
 ronin_t_windows10_64_2009_prod:
   azure2:
-    version: 1.0.2
+    version: 1.0.3
     resource_group: rg-packer-worker-images
-    deployment_id: "b1f4165"
+    deployment_id: "7769a4b"
     name: win10_64_2009
 ronin_t_windows10_64_2009_alpha:
   azure2:
@@ -169,9 +169,9 @@ ronin_t_windows11_a64_24h2_tester:
     name: win11_a64_24h2_tester
 ronin_t_windows11_64_24h2:
   azure2:
-    version: 1.0.2
+    version: 1.0.3
     resource_group: rg-packer-worker-images
-    deployment_id: "b1f4165"
+    deployment_id: "7769a4b"
     name: win11_64_24h2
 ronin_t_windows11_64_24h2_alpha:
   azure2:
@@ -187,7 +187,7 @@ ronin_t_windows11_64_2009_alpha:
     name: win11_64_2009_alpha
 ronin_t_windows11_64_2009:
   azure2:
-    version: 1.0.2
+    version: 1.0.3
     resource_group: rg-packer-worker-images
-    deployment_id: "b1f4165"
+    deployment_id: "7769a4b"
     name: win11_64_2009


### PR DESCRIPTION
Error in hg.exe on `gecko-t/win11-a64-24h2` pool in https://firefox-ci-tc.services.mozilla.com/tasks/C1Q8_lgDQamLhp3ZJjFevA

```
[vcs 2025-03-27T19:42:29.411Z] executing ['C:\\Program Files\\Mercurial\\hg.exe', 'robustcheckout', '--sharebase', 'C:\\task_174310438629963\\build\\hg-store', '--purge', '--config', 'extensions.robustcheckout=C:\\task_174310438629963\\robustcheckout.py', '--upstream', 'https://hg.mozilla.org/mozilla-unified', '--sparseprofile', 'build/sparse-profiles/startup-test', '--revision', '931a44705ab388cc72fd492e051ceda0a2827743', 'https://hg.mozilla.org/mozilla-central', 'C:\\task_174310438629963\\build\\src']
[vcs 2025-03-27T19:42:32.077Z] Traceback (most recent call last):
[vcs 2025-03-27T19:42:32.077Z]   File "hg", line 27, in <module>
[vcs 2025-03-27T19:42:32.088Z]   File "os.pyc", line 679, in __getitem__
[vcs 2025-03-27T19:42:32.089Z] KeyError: 'APPDATA'
```