### PR TITLE
clients: add non-ldap client for jcristau

### DIFF
--- a/clients.yml
+++ b/clients.yml
@@ -1523,3 +1523,8 @@ project/mozci/sheriff-automation:
     - hooks:trigger-hook:project-gecko/in-tree-action-2-generic/*
     - hooks:trigger-hook:project-gecko/in-tree-action-3-backfill/*
     - hooks:trigger-hook:project-gecko/in-tree-action-3-generic/*
+
+user/jcristau:
+  description: work around too many groups (https://github.com/taskcluster/taskcluster/issues/4333)
+  scopes:
+    - assume:mozilla-group:releng


### PR DESCRIPTION
When logging in to the UI via auth0 I end up with an auth certificate larger than 4k (due to the list of ldap and mozillians groups), causing breakage because it's included in bewit tokens in URLs and the Authorization header.  Add a static client with star scopes as a workaround.