### PR TITLE
Add github publication scopes to ios repos

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -731,6 +731,7 @@ firefox-ios:
   features:
     bitrise: true
     github-taskgraph: true
+    github-publication: true
     github-pull-request:
       policy: public_restricted
     mobile-roles: true
@@ -758,6 +759,7 @@ staging-firefox-ios:
       level: 1
   features:
     bitrise: true
+    github-publication: true
     github-taskgraph: true
     github-pull-request:
       policy: public_restricted


### PR DESCRIPTION
Similar to what the android repo used to have (16e89a0938e3bf096507ec4c1e39d98fd24273fb)