### PR TITLE
chore: bump ubuntu headless 24.04 image to pick up new generic-worker version

### DIFF
--- a/worker-images.yml
+++ b/worker-images.yml
@@ -98,7 +98,7 @@ ubuntu-2404-headless-alpha:
   fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-2404-amd64-headless-googlecompute-alpha
 ubuntu-2404-headless:
   ## Headless Image for Ubuntu 24.04
-  fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-2404-amd64-headless-googlecompute-2025-04-08
+  fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-2404-amd64-headless-googlecompute-2025-04-17
 
 ubuntu-2404-arm64-headless-alpha:
   ## alpha pool that relsre can use to rebuild and test 2404 arm64 headless ubuntu images


### PR DESCRIPTION
https://docs.taskcluster.net/docs/changelog?version=v83.5.6&audience=WORKER-DEPLOYERS