### PR TITLE
Turn off allowKVM in the default d2g worker config

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -144,6 +144,7 @@ worker-defaults:
               enableD2G: true
               allowPrivileged: false
               allowHostSharedMemory: false
+              allowKVM: false
 
 meta:
   - &persistent-disk


### PR DESCRIPTION
This more closely matches the docker-worker config, and means we don't risk this getting used on pools where it's not expected.