### PR TITLE
Bump boot disk size for b-linux-docker-alpha (bug 1959596)

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -277,7 +277,7 @@ pools:
         - minCpuPlatform: Intel Cascadelake
           disks:
             - <<: *persistent-disk
-              diskSizeGb: 20
+              diskSizeGb: 60
             - *scratch-disk
             - *scratch-disk
           machine_type: c2-standard-16


### PR DESCRIPTION
Fixes:
`Invalid value for field
'resource.disks[0].initializeParams.diskSizeGb': '20'.  Requested disk size cannot be smaller than the image size (60 GB)`