### PR TITLE
Bug 1950585 - part 4: Fix c3d-standard16-lssd as they must have 1 loc…

### DIFF
--- a/src/ciadmin/check/check_worker_pools.py
+++ b/src/ciadmin/check/check_worker_pools.py
@@ -153,9 +153,8 @@ async def check_gcp_ssds():
     worker_pools = await WorkerPoolConfig.fetch_all()
     ignore = (
         # Bug 1962119: Let's keep the number of local SSDs the same between
-        # c2 and its AMD counterparts.
+        # c2 and its AMD counterpart.
         "gecko-1/b-linux-gcp-bug1962119-c2d",
-        "gecko-1/b-linux-gcp-bug1962119-c3d",
     )
     errors = []
 

--- a/src/ciadmin/generate/worker_pools.py
+++ b/src/ciadmin/generate/worker_pools.py
@@ -617,7 +617,6 @@ def generate_pool_variants(worker_pools, environment):
         for key in (
             "image",
             "implementation",
-            "instance_types.machine_type",
             "worker-purpose",
             "worker-config.genericWorker.config.workerType",
             "worker-config.genericWorker.config.provisionerId",

--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -229,16 +229,10 @@ pools:
             - *scratch-disk
             - *scratch-disk
           machine_type: c2-standard-16
-  - pool_id: 'gecko-1/b-linux-gcp-bug1962119-{machine_series}'
+  - pool_id: 'gecko-1/b-linux-gcp-bug1962119-c2d'
     description: Worker for Firefox automation.
     owner: release+tc-workers@mozilla.com
     email_on_error: true
-    attributes:
-      machine_suffix: ""
-    variants:
-      - machine_series: c2d
-      - machine_series: c3d
-        machine_suffix: -lssd
     provider_id: fxci-level1-gcp
     config:
       minCapacity: 0
@@ -251,7 +245,23 @@ pools:
               diskSizeGb: 20
             - *scratch-disk
             - *scratch-disk
-          machine_type: "{machine_series}-standard-16{machine_suffix}"
+          machine_type: "c2d-standard-16"
+  - pool_id: 'gecko-1/b-linux-gcp-bug1962119-c3d'
+    description: Worker for Firefox automation.
+    owner: release+tc-workers@mozilla.com
+    email_on_error: true
+    provider_id: fxci-level1-gcp
+    config:
+      minCapacity: 0
+      maxCapacity: 100
+      regions: [us-central1]
+      image: monopacker-docker-worker-current
+      instance_types:
+        - disks:
+            - <<: *persistent-disk
+              diskSizeGb: 20
+            - *scratch-disk
+          machine_type: "c3d-standard-16-lssd"
 
   - pool_id: '{pool-group}/b-linux-docker-alpha'
     description: Worker for Firefox automation.


### PR DESCRIPTION
…al SSD and they're not present in us-west1

I tried to be smart in https://github.com/mozilla-releng/fxci-config/pull/349 by factorizing the config between `c2d` and `c3d`. However, their configs actually differ too much. 

`c3d` erred out: 

```
The selected machine type(c3d-standard-16-lssd) should have [1] local SSD(s).
```


```
Invalid value for field 'resource.machineType': 'zones/us-west1-b/machineTypes/c3d-standard-16-lssd'. Machine type with name 'c3d-standard-16-lssd' does not exist in zone 'us-west1-b'.
```

(same error with other subregions of `us-west1`)

The Google Console shows where this machine type is available: 

![image](https://github.com/user-attachments/assets/30424b3f-3903-43a2-b82d-fb74c5b3181b)
