### PR TITLE
Bug 1962416 - add gecko-t/t-linux-docker-kvm-alpha worker pool

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -1615,6 +1615,35 @@ pools:
             - <<: *persistent-disk
               diskSizeGb: 75
           machine_type: t2a-standard-4
+  - pool_id: 'gecko-t/t-linux-docker-kvm-alpha'
+    description: Worker for gecko-based automation.
+    owner: release+tc-workers@mozilla.com
+    email_on_error: true
+    provider_id: fxci-level1-gcp
+    config:
+      minCapacity: 0
+      maxCapacity: 100
+      regions: [us-central1, us-west1]
+      image: ubuntu-2404-headless-alpha
+      implementation: generic-worker/linux-d2g
+      worker-config:
+        genericWorker:
+          config:
+            enableInteractive: true
+            headlessTasks: true
+            disableNativePayloads: true
+            downloadsDir: /home/generic-worker/downloads
+            cachesDir: /home/generic-worker/caches
+            d2gConfig:
+              allowKVM: true
+      instance_types:
+        - minCpuPlatform: Intel Cascadelake
+          disks:
+            - <<: *persistent-disk
+              diskSizeGb: 75
+          machine_type: n2-standard-8
+          advancedMachineFeatures:
+            enableNestedVirtualization: true
   - pool_id: '{pool-group}/t-linux-2404-wayland{suffix}'  # Bug 1902716
     variants:
       - pool-group: gecko-t


### PR DESCRIPTION
Let's make sure we can test the -alpha image on these workloads.