### PR TITLE
fix: update lando repo names to match reality

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -89,7 +89,7 @@ elm:
     trust-domain-scopes: true
 mozilla-release:
   repo: https://hg.mozilla.org/releases/mozilla-release
-  lando_repo: release
+  lando_repo: firefox-release
   repo_type: hg
   access: scm_level_3
   branches:
@@ -125,7 +125,7 @@ comm-release:
     trust-domain-scopes: true
 mozilla-esr115:
   repo: https://hg.mozilla.org/releases/mozilla-esr115
-  lando_repo: esr115
+  lando_repo: firefox-esr115
   repo_type: hg
   access: scm_level_3
   branches:
@@ -145,7 +145,7 @@ mozilla-esr115:
       - periodic-update
 mozilla-esr128:
   repo: https://hg.mozilla.org/releases/mozilla-esr128
-  lando_repo: esr128
+  lando_repo: firefox-esr128
   repo_type: hg
   access: scm_level_3
   branches:
@@ -252,7 +252,7 @@ toolchains:
     trust-domain-scopes: true
 mozilla-beta:
   repo: https://hg.mozilla.org/releases/mozilla-beta
-  lando_repo: beta
+  lando_repo: firefox-beta
   repo_type: hg
   access: scm_level_3
   branches:
@@ -294,7 +294,7 @@ comm-beta:
       - l10n-bumper
 mozilla-central:
   repo: https://hg.mozilla.org/mozilla-central
-  lando_repo: main
+  lando_repo: firefox-main
   repo_type: hg
   access: scm_level_3
   branches:
@@ -483,7 +483,7 @@ jamun:
     trust-domain-scopes: true
 autoland:
   repo: https://hg.mozilla.org/integration/autoland
-  lando_repo: autoland
+  lando_repo: firefox-autoland
   repo_type: hg
   access: scm_level_3
   branches:


### PR DESCRIPTION
I learned yesterday that these are not what I thought they were. The new names match what is in https://phabricator.services.mozilla.com/diffusion/ (`firefox-main` doesn't exist yet, but it will in the near future).