### PR TITLE
Update build-decision image

### DIFF
--- a/cron-task-template.yml
+++ b/cron-task-template.yml
@@ -32,7 +32,7 @@ scopes:
   - assume:hook-id:${hookGroupId}/${hookId}
 payload:
   # built by pushes to the fxci-config repository
-  image: mozillareleases/build-decision:d9b4a81d8e114107d174994bf6be3968b34ca0db@sha256:5b1d21483c08c0698dd7f0b41f99482277375de5e5304ada1ad9d927d3899d7d
+  image: mozillareleases/build-decision:2b139bd1909ef0688663a479d30e58de809a490f@sha256:de6435a75ba4f8d579d28c9c1c907b95a09105394a4ac4072ce3a8bb0090abff
   env:
     $merge:
       - $if: allow_input

--- a/hg-push-template.yml
+++ b/hg-push-template.yml
@@ -32,7 +32,7 @@ routes:
   - index.hg-push.v1.${alias}.pushlog-id.$${payload.payload.data.pushlog_pushes[0].pushid}
 payload:
   # built by pushes to the fxci-config repository
-  image: mozillareleases/build-decision:d9b4a81d8e114107d174994bf6be3968b34ca0db@sha256:5b1d21483c08c0698dd7f0b41f99482277375de5e5304ada1ad9d927d3899d7d
+  image: mozillareleases/build-decision:2b139bd1909ef0688663a479d30e58de809a490f@sha256:de6435a75ba4f8d579d28c9c1c907b95a09105394a4ac4072ce3a8bb0090abff
   env:
     # pass along the hook payload, which is the Pulse message from hg (v2)
     # https://mozilla-version-control-tools.readthedocs.io/en/latest/hgmo/notifications.html#pulse-notifications


### PR DESCRIPTION
This is mostly to pick 410dfc7d9bd24da65800a914fc6faeb5ab1571cf up to avoid unauthenticated calls to the github API as it leads to exceeding rate limits very easily.