### PR TITLE
fix(landoscript): grant try scopes for all staging-* lando repositories

### DIFF
--- a/grants.yml
+++ b/grants.yml
@@ -3067,8 +3067,9 @@
 # allow all actions to be run through any means.
 - grant:
     - project:releng:lando:action:*
-    # this dev/test repo will probably change; but it's what we have for now
-    - project:releng:lando:repo:ff-test-dev
+    # there are staging versions of all production repos; allow try access
+    # to all of them
+    - project:releng:lando:repo:staging-*
   to:
     - project:
         alias: try


### PR DESCRIPTION
We're switching to the repositories being created in https://github.com/mozilla-conduit/lando/pull/316, which will allow us to have a RelEng controlled repository hooked up to stage Lando.