### PR TITLE
Bug 1964918 - add missing scope for index-tasks on "trunk"

### DIFF
--- a/grants.yml
+++ b/grants.yml
@@ -1014,6 +1014,7 @@
 
 - grant:
     - queue:route:index.{trust_domain}.v2.trunk.revision.*
+    - index:insert-task:{trust_domain}.v2.trunk.revision.*
   to:
     - project:
         feature: is-trunk


### PR DESCRIPTION
When index entries are added by an index-task instead of directly via routes on the task itself (as happens when the task has more than 10 routes), that index-task needs the index:insert-task scope.