### PR TITLE
bug 1965417: fix landoscript repo scope for merge day dry runs

### DIFF
--- a/grants.yml
+++ b/grants.yml
@@ -3150,7 +3150,7 @@
     - project:releng:lando:action:l10n_bump
     # in an ideal world we wouldn't grant the repo scope for dry runs
     # landoscript and taskgraph will need updates to support this
-    - project:releng:lando:repo:beta
+    - project:releng:lando:repo:firefox-beta
   to:
     - project:
         alias: mozilla-central


### PR DESCRIPTION
Ought to have been done in https://github.com/mozilla-releng/fxci-config/pull/359, but I missed it.