### PR TITLE
chore: bump ubuntu 24.04 headless image.

### DIFF
--- a/worker-images.yml
+++ b/worker-images.yml
@@ -98,7 +98,7 @@ ubuntu-2404-headless-alpha:
   fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-2404-amd64-headless-googlecompute-alpha
 ubuntu-2404-headless:
   ## Headless Image for Ubuntu 24.04
-  fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-2404-amd64-headless-googlecompute-2025-05-12
+  fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-2404-amd64-headless-googlecompute-2025-05-14
 
 ubuntu-2404-arm64-headless-alpha:
   ## alpha pool that relsre can use to rebuild and test 2404 arm64 headless ubuntu images


### PR DESCRIPTION
This will pick up https://github.com/mozilla-platform-ops/worker-images/pull/293, which picks up a new generic-worker version that is expected to fix https://github.com/mozilla/translations/issues/1117#issuecomment-2880387322.