### PR TITLE
fix: clean up merge day scope grants

### DIFF
--- a/grants.yml
+++ b/grants.yml
@@ -3125,8 +3125,6 @@
 
 # merge day scopes are a bit weird; some repositories update themselves and
 # others, while some only update themselves.
-# also: l10n_bump happens as part of merge-automation actions (but only for
-# central-to-beta)
 # TODO: replace the singular `merge_day` action with behaviour-specific scopes
 # for better granularity and protection
 
@@ -3146,15 +3144,13 @@
 # in an ideal world perhaps we'd run the actions on the target repositories
 # rather than the source ones?
 - grant:
-    - project:releng:lando:action:merge_day
-    - project:releng:lando:action:l10n_bump
     # in an ideal world we wouldn't grant the repo scope for dry runs
     # landoscript and taskgraph will need updates to support this
     - project:releng:lando:repo:firefox-beta
   to:
     - project:
         alias: mozilla-central
-        job: [cron:merge-central-to-beta-dry-run, action:merge-automation]
+        job: action:merge-automation
 
 - grant:
     - project:releng:lando:repo:firefox-release


### PR DESCRIPTION
A couple of small things:
* Remove unnecessary `merge_day` scope grant in central-to-beta block (it's granted just above)
* Remove unnecessary direct scope grants for cron tasks (they `assume` the action scopes)
* Remove `l10n_bump` scope grant for merge-automation (no longer needed after https://github.com/mozilla-releng/scriptworker-scripts/pull/1207)