### PR TITLE
bug 1967638: feat: add scopes for `main-to-beta` cron task

### DIFF
--- a/grants.yml
+++ b/grants.yml
@@ -585,6 +585,12 @@
         level: [3]
         alias: [mozilla-beta]
     - project:
+        job: [cron:merge-main-to-beta-dry-run]
+        trust_domain: gecko
+        level: [3]
+        alias: [mozilla-central]
+    # TODO: remove central-to-beta entry once https://bugzilla.mozilla.org/show_bug.cgi?id=1967638 is fixed
+    - project:
         job: [cron:merge-central-to-beta-dry-run]
         trust_domain: gecko
         level: [3]


### PR DESCRIPTION
`central-to-beta` scope will be removed once this is renamed in Gecko.