### PR TITLE
Add scopes to create ios releases on mobile-1-dev shipit scriptworker

### DIFF
--- a/clients.yml
+++ b/clients.yml
@@ -1049,6 +1049,13 @@ project/releng/scriptworker/v2/shipit/prod/firefoxci-gecko-3:
     - project:releng:services/shipit_api/update_release_status
     - queue:claim-work:scriptworker-k8s/gecko-3-shipit
     - queue:worker-id:gecko-3-shipit/gecko-3-shipit-*
+project/releng/scriptworker/v2/shipit/dev/firefoxci-mobile-1:
+  description: "mobile level 1 nonprod shipit scriptworker"
+  scopes:
+    - project:releng:services/shipit_api/add_release/firefox-ios
+    - project:releng:services/shipit_api/schedule_phase/firefox-ios/promote
+    - project:releng:services/shipit_api/schedule_phase/firefox-ios/push
+    - project:releng:services/shipit_api/schedule_phase/firefox-ios/ship
 project/releng/scriptworker/v2/signing/dev/firefoxci-adhoc-t:
   description: Adhoc signing dev signing scriptworker client
   scopes:


### PR DESCRIPTION
I'm not sure this is correct, I don't understand why we have to have 3 of the same scopes (no prefix/dev/staging) but that seems to be what other shipit dev workers do 🤷