### PR TITLE
Bug 1925873 - switch code-coverage/bot-gcp pool back to c2-standard-4

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -3220,10 +3220,7 @@ pools:
             - <<: *persistent-disk
               diskSizeGb: 75
             - *scratch-disk
-            - *scratch-disk
-            - *scratch-disk
-            - *scratch-disk
-          machine_type: c2-standard-30
+          machine_type: c2-standard-4
       worker-config:
         shutdown:
           afterIdleSeconds: 900


### PR DESCRIPTION
grcov is currently OOMing even with 120G, so get back to a reasonably sized instance assuming that when we update grcov it won't need silly amounts of memory anymore.