### PR TITLE
Support Autoland or Mozilla-Central pulse trigger for code-review testing hook

### DIFF
--- a/hooks/project-relman/code-review-testing.yml
+++ b/hooks/project-relman/code-review-testing.yml
@@ -53,7 +53,7 @@ payload:
           else:
             # Triggered by end of build on autoland & MC
             GENERIC_TASK_GROUP_ID:
-              $eval: payload.status.taskGroupId
+              $eval: payload.taskGroupId
   features:
     taskclusterProxy: true
   image:

--- a/hooks/project-relman/code-review-testing.yml
+++ b/hooks/project-relman/code-review-testing.yml
@@ -39,12 +39,21 @@ payload:
       - $if: firedBy == 'pulseMessage'
         else: {}
         then:
-          TRY_RUN_ID:
-            $eval: payload.runId
-          TRY_TASK_GROUP_ID:
-            $eval: payload.status.taskGroupId
-          TRY_TASK_ID:
-            $eval: payload.status.taskId
+          $if: {$eval: '"runId" in payload && "status" in payload'}
+          then:
+            # Trigerred by code-review task in try ending
+            # so we can analyze a try patch
+            TRY_RUN_ID:
+              $eval: payload.runId
+            TRY_TASK_GROUP_ID:
+              $eval: payload.status.taskGroupId
+            TRY_TASK_ID:
+              $eval: payload.status.taskId
+
+          else:
+            # Triggered by end of build on autoland & MC
+            GENERIC_TASK_GROUP_ID:
+              $eval: payload.status.taskGroupId
   features:
     taskclusterProxy: true
   image:


### PR DESCRIPTION
Refs https://github.com/mozilla/code-review/pull/2801 & https://github.com/mozilla/code-review/issues/2773

The code-review hook must support pulse message triggers sent at the end of Mozilla Central & Autoland build groups.

We already did that by using the [events sub-system](https://github.com/mozilla/code-review/blob/95b29a76006f7c5462a7c096a95055b3b978ed33/events/code_review_events/workflow.py#L404), but now we only use the bot through its hook.

The hook will now have 2 pulse triggers:
1. from try pushes, transforming the payload into `TRY_RUN_ID`, `TRY_TASK_GROUP_ID` and `TRY_TASK_ID` environment variables
2. from Autoland / MC groups, transforming the payload into a unique `GENERIC_TASK_GROUP_ID`

## Sample payload from try push

```json
{
  "status": {
    "taskId": "ALywAOE0SDiwzjQMSkmTMQ",
    "provisionerId": "gecko-1",
    "workerType": "b-linux-gcp",
    "taskQueueId": "gecko-1/b-linux-gcp",
    "schedulerId": "gecko-level-1",
    "projectId": "none",
    "taskGroupId": "GXjaWu_kRoy6AP0yeeN60w",
    "deadline": "2025-05-27T15:09:57.208Z",
    "expires": "2025-06-23T15:09:57.208Z",
    "retriesLeft": 5,
    "state": "completed",
    "runs": [
      {
        "runId": 0,
        "state": "completed",
        "reasonCreated": "scheduled",
        "reasonResolved": "completed",
        "workerGroup": "us-central1-f",
        "workerId": "3186105317030741419",
        "takenUntil": "2025-05-26T15:40:28.694Z",
        "scheduled": "2025-05-26T15:20:26.826Z",
        "started": "2025-05-26T15:20:28.697Z",
        "resolved": "2025-05-26T15:20:40.971Z"
      }
    ]
  },
  "runId": 0,
  "task": {
    "tags": {
      "os": "linux",
      "kind": "code-review",
      "label": "code-review-issues",
      "project": "try",
      "retrigger": "false",
      "trust-domain": "gecko",
      "createdForUser": "reviewbot@noreply.mozilla.org",
      "worker-implementation": "docker-worker"
    }
  },
  "workerGroup": "us-central1-f",
  "workerId": "3186105317030741419",
  "version": 1
}
```

## from Autoland / MC groups

```json
{
  "taskGroupId": "ZRLgYvpiS0iS9MQUtdC-3w",
  "schedulerId": "gecko-level-3",
  "expires": "2025-06-02T16:15:00.000Z",
  "version": 1
}
```