### PR TITLE
Add the required scopes and hooks for firefox ios to run automated betas

### DIFF
--- a/clients.yml
+++ b/clients.yml
@@ -1014,6 +1014,13 @@ project/releng/scriptworker/v2/shipit/prod/firefoxci-gecko-3:
     - project:releng:services/shipit_api/update_release_status
     - queue:claim-work:scriptworker-k8s/gecko-3-shipit
     - queue:worker-id:gecko-3-shipit/gecko-3-shipit-*
+project/releng/scriptworker/v2/shipit/prod/firefoxci-mobile-1:
+  description: "mobile level 1 shipit scriptworker"
+  scopes:
+    - project:releng:services/shipit_api/add_release/firefox-ios
+    - project:releng:services/shipit_api/schedule_phase/firefox-ios/promote
+    - project:releng:services/shipit_api/schedule_phase/firefox-ios/push
+    - project:releng:services/shipit_api/schedule_phase/firefox-ios/ship
 project/releng/scriptworker/v2/shipit/prod/firefoxci-mobile-3:
   description: "mobile level 3 shipit scriptworker"
   scopes:

--- a/clients.yml
+++ b/clients.yml
@@ -1014,6 +1014,13 @@ project/releng/scriptworker/v2/shipit/prod/firefoxci-gecko-3:
     - project:releng:services/shipit_api/update_release_status
     - queue:claim-work:scriptworker-k8s/gecko-3-shipit
     - queue:worker-id:gecko-3-shipit/gecko-3-shipit-*
+project/releng/scriptworker/v2/shipit/prod/firefoxci-mobile-3:
+  description: "mobile level 3 shipit scriptworker"
+  scopes:
+    - project:releng:services/shipit_api/add_release/firefox-ios
+    - project:releng:services/shipit_api/schedule_phase/firefox-ios/promote
+    - project:releng:services/shipit_api/schedule_phase/firefox-ios/push
+    - project:releng:services/shipit_api/schedule_phase/firefox-ios/ship
 project/releng/scriptworker/v2/shipit/dev/firefoxci-mobile-1:
   description: "mobile level 1 nonprod shipit scriptworker"
   scopes:

--- a/grants.yml
+++ b/grants.yml
@@ -1729,6 +1729,17 @@
         job:
           - cron:beta-releases
 
+
+- grant:
+    - project:{trust_domain}:releng:ship-it:server:production
+    - project:{trust_domain}:releng:ship-it:action:create-new-release
+  to:
+    - project:
+        alias:
+          - firefox-ios
+        job:
+          - cron:beta-releases
+
 - grant:
     - secrets:get:project/mobile/ci/testrail
   to:

--- a/projects.yml
+++ b/projects.yml
@@ -750,6 +750,7 @@ firefox-ios:
   cron:
     targets:
       - l10-screenshots
+      - beta-releases
       - bitrise-performance-test
       - firebase-performance-test
 


### PR DESCRIPTION
This is a basically 8aceceb2d43a04a492d4adfd8263d4eb362d4df2, 22790145b650633e6c4e4d24c9e4569309fee097 and
0239d534afe83704fc1adb1e45d95e9b75546469 but for firefox-ios instead of staging-firefox-ios and targeting shipit prod