### PR TITLE
chore: set all translations alpha gpu pools to use `ubuntu-2404-headless-alpha-tc` image

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -2086,7 +2086,7 @@ pools:
       maxCapacity: 200
       implementation: generic-worker/linux-d2g
       regions: [us-central1, us-west1, us-east1]
-      image: ubuntu-2404-headless-alpha
+      image: ubuntu-2404-headless-alpha-tc
       instance_types:
         - minCpuPlatform: Intel Skylake
           disks:
@@ -2160,7 +2160,7 @@ pools:
       maxCapacity: 128
       implementation: generic-worker/linux-d2g
       regions: [us-central1, us-west1, us-east1]
-      image: ubuntu-2404-headless-alpha
+      image: ubuntu-2404-headless-alpha-tc
       instance_types:
         - minCpuPlatform: Intel Skylake
           disks:
@@ -2235,7 +2235,7 @@ pools:
       maxCapacity: 128
       implementation: generic-worker/linux-d2g
       regions: [us-central1, us-west1, us-east1]
-      image: ubuntu-2404-headless-alpha
+      image: ubuntu-2404-headless-alpha-tc
       instance_types:
         - minCpuPlatform: Intel Skylake
           disks:
@@ -2306,7 +2306,7 @@ pools:
       maxCapacity: 50
       implementation: generic-worker/linux-d2g
       regions: [us-central1, us-west1]
-      image: ubuntu-2404-headless-alpha
+      image: ubuntu-2404-headless-alpha-tc
       instance_types:
         - minCpuPlatform: Intel Skylake
           disks:
@@ -2378,7 +2378,7 @@ pools:
       maxCapacity: 50
       implementation: generic-worker/linux-d2g
       regions: [us-central1, us-west1]
-      image: ubuntu-2404-headless-alpha
+      image: ubuntu-2404-headless-alpha-tc
       instance_types:
         - minCpuPlatform: Intel Skylake
           disks:
@@ -2531,7 +2531,7 @@ pools:
       maxCapacity: 128
       implementation: generic-worker/linux-d2g
       regions: [us-central1, us-west1, us-east1]
-      image: ubuntu-2404-headless-alpha
+      image: ubuntu-2404-headless-alpha-tc
       instance_types:
         - minCpuPlatform: Intel Skylake
           disks:


### PR DESCRIPTION
To test a larger training run on TC binaries built off of https://github.com/taskcluster/taskcluster/pull/7761.