### PR TITLE
Remove $eval in $if condition for code-review testing hook

### DIFF
--- a/hooks/project-relman/code-review-testing.yml
+++ b/hooks/project-relman/code-review-testing.yml
@@ -39,9 +39,9 @@ payload:
       - $if: firedBy == 'pulseMessage'
         else: {}
         then:
-          $if: {$eval: '"runId" in payload && "status" in payload'}
+          $if: '"runId" in payload && "status" in payload'
           then:
-            # Trigerred by code-review task in try ending
+            # Triggered by code-review task in try ending
             # so we can analyze a try patch
             TRY_RUN_ID:
               $eval: payload.runId


### PR DESCRIPTION
Followup #403

The [code-review-testing hook](https://firefox-ci-tc.services.mozilla.com/hooks/project-relman/code-review-testing) has been updated with the changes from #403, but all the trigerred tasks now fail with that error:

```
    TemplateError at template.payload.env[2]: $if can evaluate string expressions only
```

