### PR TITLE
Disable generic-worker OOM protection for t-linux-2404-headless-ssd-alpha

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -1607,6 +1607,7 @@ pools:
             headlessTasks: true
             downloadsDir: /home/generic-worker/downloads
             cachesDir: /home/generic-worker/caches
+            disableOOMProtection: true
       minCapacity: 0
       maxCapacity: 10
       implementation: generic-worker/linux-d2g


### PR DESCRIPTION
I have a task that seems to hit this, I would like to test on try if it passes consistently with the check turned off.