### PR TITLE
Support Autoland or Mozilla-Central pulse trigger for code-review production hook

### DIFF
--- a/hooks.yml
+++ b/hooks.yml
@@ -189,6 +189,8 @@ project-relman/code-review-production:
   bindings:
     - exchange: exchange/taskcluster-queue/v1/task-completed
       routing_key_pattern: route.project.relman.codereview.v1.try_ending
+    - exchange: exchange/taskcluster-queue/v1/task-group-resolved
+      routing_key_pattern: '#.gecko-level-3.#'
   trigger_schema:
     type: object
     additionalProperties: true

--- a/hooks/project-relman/code-review-production.yml
+++ b/hooks/project-relman/code-review-production.yml
@@ -39,12 +39,21 @@ payload:
       - $if: firedBy == 'pulseMessage'
         else: {}
         then:
-          TRY_RUN_ID:
-            $eval: payload.runId
-          TRY_TASK_GROUP_ID:
-            $eval: payload.status.taskGroupId
-          TRY_TASK_ID:
-            $eval: payload.status.taskId
+          $if: '"runId" in payload && "status" in payload'
+          then:
+            # Triggered by code-review task in try ending
+            # so we can analyze a try patch
+            TRY_RUN_ID:
+              $eval: payload.runId
+            TRY_TASK_GROUP_ID:
+              $eval: payload.status.taskGroupId
+            TRY_TASK_ID:
+              $eval: payload.status.taskId
+
+          else:
+            # Triggered by end of build on autoland & MC
+            GENERIC_TASK_GROUP_ID:
+              $eval: payload.taskGroupId
   features:
     taskclusterProxy: true
   image:

--- a/hooks/project-relman/code-review-production.yml
+++ b/hooks/project-relman/code-review-production.yml
@@ -52,6 +52,7 @@ payload:
 
           else:
             # Triggered by end of build on autoland & MC
+            # and other unsupported level-3 branches (skipped by bot)
             GENERIC_TASK_GROUP_ID:
               $eval: payload.taskGroupId
   features:


### PR DESCRIPTION
This is the same patch as #403 + #413 for code-review production hook.

---
Refs https://github.com/mozilla/code-review/pull/2801 & https://github.com/mozilla/code-review/issues/2773

The code-review hook must support pulse message triggers sent at the end of Mozilla Central & Autoland build groups.

We already did that by using the [events sub-system](https://github.com/mozilla/code-review/blob/95b29a76006f7c5462a7c096a95055b3b978ed33/events/code_review_events/workflow.py#L404), but now we only use the bot through its hook.

The hook will now have 2 pulse triggers:
1. from try pushes, transforming the payload into `TRY_RUN_ID`, `TRY_TASK_GROUP_ID` and `TRY_TASK_ID` environment variables
2. from Autoland / MC groups, transforming the payload into a unique `GENERIC_TASK_GROUP_ID`