### PR TITLE
bump 24.04 headless image to tc 84.2.0

### DIFF
--- a/worker-images.yml
+++ b/worker-images.yml
@@ -98,7 +98,7 @@ ubuntu-2404-headless-alpha:
   fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-2404-amd64-headless-googlecompute-alpha
 ubuntu-2404-headless:
   ## Headless Image for Ubuntu 24.04
-  fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-2404-amd64-headless-googlecompute-2025-05-20
+  fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-2404-amd64-headless-googlecompute-2025-06-13
 
 ubuntu-2404-headless-alpha-tc:
   ## alpha pool that tc can use to rebuild and test 2404 headless ubuntu images


### PR DESCRIPTION
Try push for headless alpha image https://treeherder.mozilla.org/jobs?repo=try&revision=4b601c6c563a6692a7060aa46b02e65d6d16db68