### PR TITLE
Revert "Disable generic-worker OOM protection for t-linux-2404-headless-ssd-alpha"

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -1607,7 +1607,6 @@ pools:
             headlessTasks: true
             downloadsDir: /home/generic-worker/downloads
             cachesDir: /home/generic-worker/caches
-            disableOOMProtection: true
       minCapacity: 0
       maxCapacity: 10
       implementation: generic-worker/linux-d2g


### PR DESCRIPTION
Reverts mozilla-releng/fxci-config#419

https://github.com/taskcluster/taskcluster/pull/7775 lets us tweak the OOM detection parameters.