### PR TITLE
Turn off cron for comm-esr140 for now

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -194,7 +194,7 @@ comm-esr115:
   parent_repo: https://hg.mozilla.org/releases/mozilla-esr115
   features:
     gecko-actions: true
-    gecko-cron: true
+    gecko-cron: false
     gecko-roles: true
     hg-push: true
     treeherder-reporting: true


### PR DESCRIPTION
The cron hook fails and spams sheriffs while the repo's pushlog is empty.