### PR TITLE
feat: don't fail cron runs when pushlog is empty

### DIFF
--- a/build-decision/src/build_decision/repository.py
+++ b/build-decision/src/build_decision/repository.py
@@ -14,10 +14,8 @@ from .util.http import SESSION
 logger = logging.getLogger(__name__)
 
 
-class RetryableError(Exception):
-    """
-    An error that can automatially be retried.
-    """
+class NoPushesError(Exception):
+    pass
 
 
 @attr.s(frozen=True)
@@ -78,7 +76,7 @@ class Repository:
         attempts=5,
         sleeptime=10,
         retry_exceptions=(
-            RetryableError,
+            NoPushesError,
             ChunkedEncodingError,
             ConnectionError,
             SSLError,
@@ -104,7 +102,7 @@ class Repository:
                 # If we query immediately after a push, hg.mozilla.org might
                 # report that there are no pushes associated to a changeset.
                 # We retry, since this tends to be a transient error.
-                raise RetryableError(
+                raise NoPushesError(
                     f"Changeset {revset} has no associated pushes. "
                     "Maybe the push log has not been updated?"
                 )

--- a/build-decision/tests/test_cron.py
+++ b/build-decision/tests/test_cron.py
@@ -185,6 +185,7 @@ def test_run_no_pushes(mocker):
     """Ensure that running cron.hook does nothing when no pushes are found,
     and doesn't raise an Exception."""
     fake_repo = mocker.MagicMock()
+
     def fake_get_push_info(*args, **kwargs):
         raise NoPushesError()
 

--- a/build-decision/tests/test_repository.py
+++ b/build-decision/tests/test_repository.py
@@ -105,11 +105,11 @@ def test_get_file(mocker, repository_type, repo_url, revision, raises, expected_
     "branch, revision, pushes, raises, expected",
     (
         (
-            # RetryableError on empty pushes
+            # NoPushesError on empty pushes
             "branch",
             None,
             {"pushes": []},
-            repository.RetryableError,
+            repository.NoPushesError,
             None,
         ),
         (


### PR DESCRIPTION
This seems to be a footgun when setting up a new repository: you can't add it to fxci-config until you push to it, which is both unintuitive, and seems less than ideal (any push you make wouldn't have jobs run, i think?).

Theoretically this could happen if there's an issue on hg.m.o, but I'm not sure that's worth worrying about.