### PR TITLE
Bug 1961225: feat(build-decision): should retry on some requests exceptions

### DIFF
--- a/build-decision/src/build_decision/repository.py
+++ b/build-decision/src/build_decision/repository.py
@@ -74,7 +74,16 @@ class Repository:
 
         return yaml.safe_load(tcyml)
 
-    @redo.retriable(attempts=5, sleeptime=10, retry_exceptions=(RetryableError,ChunkedEncodingError,ConnectionError,SSLError))
+    @redo.retriable(
+        attempts=5,
+        sleeptime=10,
+        retry_exceptions=(
+            RetryableError,
+            ChunkedEncodingError,
+            ConnectionError,
+            SSLError,
+        ),
+    )
     def get_push_info(self, *, revision=None, branch=None):
         if branch and revision:
             raise ValueError("Can't pass both revision and branch to get_push_info")


### PR DESCRIPTION
These ones we should obviously retry on. The other exceptions that [iter_content can raise](https://github.com/psf/requests/blob/91a3eabd3dcc4d7f36dd8249e4777a90ef9b4305/src/requests/models.py#L821-L828) I'm less certain about. (`DecodeError` and `SSLError` don't strike me as something that would necessarily be fixed with an immediate retry, but maybe we should retry on them just in case?)