### PR TITLE
bug 1973252: chore: grant patricia wong access to run release promotion in L1 repositories

### DIFF
--- a/grants.yml
+++ b/grants.yml
@@ -2716,6 +2716,13 @@
     - roles:
         - login-identity:mozilla-auth0/ad|Mozilla-LDAP|afranchuk
 
+# Bug 1973252: grant pwong access to run release promotion on Try
+- grant:
+    - hooks:trigger-hook:project-gecko/in-tree-action-1-release-promotion/*
+  to:
+    - roles:
+        - login-identity:mozilla-auth0/ad|Mozilla-LDAP|pwong
+
 # Mappings from `mozilla-group`s to `project-releng:ci-group`s
 # This indirection exists because modifying `mozilla-group`s requires
 # access to the root credentials.


### PR DESCRIPTION
Patricia is working on adding new types of update tests that run as part of release promotion. She needs to be able to test them on Try to keep working on them without running through us.

I don't think we need to bother with Ship It access for this; I plan to show her how to run them through Treeherder directly (in particular, so she can avoid needing new builds each time she pushes to Try).