### PR TITLE
fix: make translations integration tests work without mirroring fetch tasks

### DIFF
--- a/taskcluster/kinds/firefoxci-artifact/kind.yml
+++ b/taskcluster/kinds/firefoxci-artifact/kind.yml
@@ -56,7 +56,15 @@ tasks:
       # tasks they normally would be.
       # docker-image tasks are excluded because there's no value in rerunning
       # them as part of integration tests.
-      - ^(?!(Decision|Action|PR action|build-docker-image|docker-image)).*
+      # fetch tasks are excluded because there's no value in rerunning them,
+      # and also because they live forever, and depend on docker images which
+      # expire, which causes us to try to mirror expired docker image tasks
+      # into the staging cluster
+      - ^(?!(Decision|Action|PR action|build-docker-image|docker-image|fetch)).*
+    # Tasks that depend on artifacts from mirrored and non-mirrored tasks
+    # must be listed here to ensure that all `MOZ_FETCHES` entries point
+    # at the same cluster. Generally, these are tasks that depend on an
+    # unmirrored, non-docker image task in addition to a mirrored task.
     mirror-public-fetches:
       - ^toolchain.*
-      - ^fetch.*
+      - ^corpus-clean-parallel-bicleaner-ai.*

--- a/taskcluster/kinds/integration-test/kind.yml
+++ b/taskcluster/kinds/integration-test/kind.yml
@@ -38,4 +38,8 @@ tasks:
       # tasks they normally would be.
       # docker-image tasks are excluded because there's no value in rerunning
       # them as part of integration tests.
-      - ^(?!(Decision|Action|PR action|build-docker-image|docker-image)).*
+      # fetch tasks are excluded because there's no value in rerunning them,
+      # and also because they live forever, and depend on docker images which
+      # expire, which causes us to try to mirror expired docker image tasks
+      # into the staging cluster
+      - ^(?!(Decision|Action|PR action|build-docker-image|docker-image|fetch)).*


### PR DESCRIPTION
This is a second attempt at a fix for https://bugzilla.mozilla.org/show_bug.cgi?id=1961216, which avoids the [timebomb I called out when it was reviewed](https://github.com/mozilla-releng/fxci-config/pull/361/files#r2070269056).

As it turns out, I already solved the problem of needing fetches from two clusters for toolchain tasks, where we have some that depend on other toolchains + fetches. Backing out the original fix for this, and marking `corpus-clean-parallel-bicleaner-ai` as a task that needs its public upstream artifacts mirrored solves this.

It still feels like there's a bug here in that with the fetch tasks mirrored, we shouldn't need to rely on `mirror-public-fetches` to use the staging cluster version of the tasks. I haven't had time to run that down though, and this should get these tests working again...