### PR TITLE
Bug 1965145 - Add new lando scopes for Thunderbird repos

### DIFF
--- a/grants.yml
+++ b/grants.yml
@@ -3137,7 +3137,7 @@
     - project:releng:lando:repo:{lando_repo}
   to:
     - project:
-        alias: [mozilla-central, mozilla-beta, mozilla-esr115, mozilla-esr128, mozilla-esr140]
+        alias: [mozilla-central, mozilla-beta, mozilla-esr115, mozilla-esr128, mozilla-esr140, comm-central, comm-beta, comm-esr115, comm-esr128, comm-esr140]
         job: action:merge-automation
 
 # granting scopes for cross-repo updates is also straightforward, but it looks


### PR DESCRIPTION
Adding these to hopefully fix our merge automation.

I've excluded the android scopes, since Thunderbird for Android uses our own infrastructure.