### PR TITLE
refactor: use development/production for translations bucket names

### DIFF
--- a/grants.yml
+++ b/grants.yml
@@ -2986,7 +2986,7 @@
 
 # Beetmover scopes for Translations
 - grant:
-    - project:translations:releng:beetmover:bucket:dep
+    - project:translations:releng:beetmover:bucket:development
   to:
     - project:
         alias:
@@ -2998,7 +2998,7 @@
           - pr-action:train
 
 - grant:
-    - project:translations:releng:beetmover:bucket:release
+    - project:translations:releng:beetmover:bucket:production
   to:
     - project:
         alias:


### PR DESCRIPTION
After a discussion with the translations folks we decided to rename these to avoid RelEng-jargon: https://github.com/mozilla/translations/pull/590#discussion_r2183372612

Should wait for https://github.com/mozilla-releng/scriptworker-scripts/pull/1249 before it lands.