### PR TITLE
Bug 1976483 - Grant os-integration scopes to worker-images repo

### DIFF
--- a/grants.yml
+++ b/grants.yml
@@ -1216,7 +1216,14 @@
     - project:
         trust_domain: releng
 
-# - fxci-config specific roles
+# Cross trust-domain os-integration test scopes.
+# These scopes are necessary to run tests from other trust domains on repos where
+# we manage Taskcluster configuration, like fxci-config and worker-images. These
+# tests help us ensure we don't break downstream tasks before changing the pools
+# they run on.
+#
+# Running tasks on other trust domain's pools is not a good practice, so make
+# sure we're only granting level 1 pools and other non-sensitive scopes here.
 - grant:
     # There's a task in the staging instance that runs on fxci-config pull requests
     # which applies the config directly from a pull request. This task resets the
@@ -1228,6 +1235,13 @@
     # This is only used to authenticate as the taskcluster-staging app to avoid
     # Github rate limits.
     - secrets:get:project/releng/tc-github-private-key
+  to:
+    - project:
+        alias: fxci-config
+        job: [pull-request:trusted]
+  environments: staging
+
+- grant: &os-integration
     # We grant ability to create `gecko-t` tasks in the staging instance so we
     # can validate image changes before they land.
     - queue:create-task:low:gecko-t/*
@@ -1247,6 +1261,12 @@
         alias: fxci-config
         job: [pull-request:trusted]
   environments: staging
+
+- grant: *os-integration
+  to:
+    - project:
+        alias: worker-images
+        job: [pull-request:trusted]
 
 # - k8s-autoscale roles
 - grant:


### PR DESCRIPTION
Here's the tc-admin diff:

```diff
--- current
+++ generated
@@ -314715,32 +314715,42 @@ Role=repo:github.com/mozilla-platform-ops/worker-images:pr-action:*:

   Role=repo:github.com/mozilla-platform-ops/worker-images:pull-request:
     roleId: repo:github.com/mozilla-platform-ops/worker-images:pull-request
     description:
       *DO NOT EDIT* - This resource is configured automatically by [ci-admin](https://github.com/mozilla-releng/fxci-config).

       Scopes in this role are defined in [fxci-config/grants.yml](https://github.com/mozilla-releng/fxci-config/blob/main/grants.yml).
     scopes:
+      - assume:repo:github.com/mozilla/translations:action:train
       - docker-worker:cache:relops-level-1-*
       - docker-worker:cache:relops-project-worker-images-level-1-*
+      - docker-worker:capability:device:kvm
+      - docker-worker:capability:device:loopbackVideo
+      - docker-worker:feature:allowPtrace
       - generic-worker:cache:relops-level-1-*
       - generic-worker:cache:relops-project-worker-images-level-1-*
       - in-tree:hook-action:project-relops/in-tree-action-1-*
       - in-tree:hook-action:project-relops/in-tree-pr-action-1-*
       - index:insert-task:relops.v2.worker-images-pr.*
       - index:insert-task:relops.v2.worker-images.cache.head.*
       - index:insert-task:relops.v2.worker-images.cache.level-1.*
       - index:insert-task:relops.v2.worker-images.cache.pr.*
+      - project:releng:services/tooltool/api/download/internal
+      - project:releng:services/tooltool/api/download/public
       - queue:cancel-task-group:relops-level-1/*
       - queue:cancel-task:relops-level-1/*
       - queue:create-task:highest:built-in/*
       - queue:create-task:highest:releng-hardware/relops-b-1-*
       - queue:create-task:highest:relops-1/*
       - queue:create-task:highest:relops-t/*
+      - queue:create-task:low:gecko-t/*
+      - queue:create-task:low:translations-1/decision-gcp
+      - queue:get-artifact:project/gecko/android-emulator/*
+      - queue:get-artifact:project/gecko/android-system-images/*
       - queue:rerun-task:relops-level-1/*
       - queue:route:checks
       - queue:route:index.relops.v2.worker-images-pr.*
       - queue:route:index.relops.v2.worker-images.cache.head.*
       - queue:route:index.relops.v2.worker-images.cache.level-1.*
       - queue:route:index.relops.v2.worker-images.cache.pr.*
       - queue:scheduler-id:relops-level-1
       - queue:seal-task-group:relops-level-1/*
```