### PR TITLE
Add local ssd to t-linux-docker-kvm{,-alpha} pools (bug 1976867)

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -1637,6 +1637,7 @@ pools:
           disks:
             - <<: *persistent-disk
               diskSizeGb: 75
+            - <<: *scratch-disk
           machine_type: n2-standard-8
           advancedMachineFeatures:
             enableNestedVirtualization: true
@@ -3255,6 +3256,7 @@ pools:
           disks:
             - <<: *persistent-disk
               diskSizeGb: 75
+            - <<: *scratch-disk
           machine_type: n2-standard-8
           advancedMachineFeatures:
             enableNestedVirtualization: true


### PR DESCRIPTION
Extracting fetches for android emulator jobs appears to be usually twice as slow on the persistent disk, and occasionally extremely slow.