### PR TITLE
fix: include startup tests in firefoxci-artifact include-attrs

### DIFF
--- a/taskcluster/kinds/firefoxci-artifact/kind.yml
+++ b/taskcluster/kinds/firefoxci-artifact/kind.yml
@@ -37,6 +37,7 @@ tasks:
     include-attrs:
       kind:
         - source-test
+        - startup-test
         - test
     exclude-attrs:
       test_platform:


### PR DESCRIPTION
Without it, we clone the startup-test tasks but not their docker images and get errors such as:
```
Exception: Task 'gecko-startup-test-linux64-aarch64' lists a dependency that does not exist: 'firefoxci-artifact-gecko-F0RmCHwIR2qU-CvV3sOkzA'
```

Oversight from #456