### PR TITLE
feat: generate cron hook for os-integration tests

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -359,6 +359,7 @@ mozilla-central:
       - periodic-update
       - system-symbols
       - l10n-cross-channel
+      - os-integration
       - target: scriptworker-canary
         allow-input: true
 comm-central:


### PR DESCRIPTION
These fail sometimes, and it can be useful to run them again by hand.