### PR TITLE
ci: allow manually triggering the 'deploy' action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:  # yamllint disable-line rule:truthy
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  workflow_dispatch: {}
 
 permissions:
   contents: read


### PR DESCRIPTION
I think this is all that's needed...

But it's hard to test because it needs to exist on the default branch first.