### PR TITLE
fix: allow input in worker-image's 'run-integration-tests' target

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -1095,7 +1095,8 @@ worker-images:
     trust-domain-scopes: true
   cron:
     targets:
-      - run-integration-tests
+      - target: run-integration-tests
+        allow-input: true
 
 # Mozilla VPN
 mozilla-vpn-client:


### PR DESCRIPTION
This target is going to be triggered during the image deploy pipeline (which is in GH Actions). So the GH Action workflow will pass in the name of the image being deployed, which will then be used during Taskgraph's optimization phase to only run relevant tasks.