### PR TITLE
Support rendering .tc.yml with cron input for decision type

### DIFF
--- a/build-decision/src/build_decision/cron/schema.yml
+++ b/build-decision/src/build_decision/cron/schema.yml
@@ -94,6 +94,11 @@ definitions:
                     type: array
                     items: {type: string}
                     description: Kinds that should not be re-used from the on-push graph.
+                include-cron-input:
+                    type: boolean
+                    description: >-
+                        Whether the input to the cron hook should be added to the context
+                        used to render .taskcluster.yml.
         trigger-action:
             required: ["type", "action-name"]
             additionalProperties: false


### PR DESCRIPTION
When triggering a cron hook, it's possible to specify a payload at trigger time. For the "action" type of cron task, it's further possible to forward this input to the action as action input. But for the decision cron type, this input is dropped.

This change adds a way for the input to get added to the context used to render the .taskcluster.yml file, which allows consumers to use it with the "decision" type of cron.