### PR TITLE
fix: add 'taskcluster_root_url' to build-decision render context

### DIFF
--- a/build-decision/src/build_decision/cron/decision.py
+++ b/build-decision/src/build_decision/cron/decision.py
@@ -58,6 +58,7 @@ def run_decision_task(job_name, job, *, repository, push_info, dry_run):
 
     task = render_tc_yml(
         taskcluster_yml,
+        taskcluster_root_url=os.environ["TASKCLUSTER_ROOT_URL"],
         tasks_for="cron",
         repository=repository.to_json(),
         push=push_info,

--- a/build-decision/src/build_decision/hg_push.py
+++ b/build-decision/src/build_decision/hg_push.py
@@ -58,6 +58,7 @@ def build_decision(*, repository, taskcluster_yml_repo, dry_run):
 
     task = render_tc_yml(
         taskcluster_yml,
+        taskcluster_root_url=os.environ["TASKCLUSTER_ROOT_URL"],
         tasks_for="hg-push",
         push=push,
         repository=repository.to_json(),

--- a/build-decision/tests/test_cron_decision.py
+++ b/build-decision/tests/test_cron_decision.py
@@ -42,6 +42,9 @@ def test_make_arguments(job, expected):
 
 @pytest.fixture
 def run_decision_task(mocker):
+    mocker.patch.object(
+        os, "environ", new={"TASKCLUSTER_ROOT_URL": "http://taskcluster.local"}
+    )
     job_name = "abc"
 
     def inner(job=None, dry_run=False, env=None):
@@ -86,7 +89,10 @@ def test_dry_run(run_decision_task, dry_run):
         mocks["hook"].submit.assert_not_called()
 
 
-def test_cron_input(run_decision_task):
+def test_cron_input(mocker, run_decision_task):
+    mocker.patch.object(
+        os, "environ", new={"TASKCLUSTER_ROOT_URL": "http://taskcluster.local"}
+    )
     mock = run_decision_task()["render"]
     mock.assert_called_once()
     kwargs = mock.call_args_list[0][1]


### PR DESCRIPTION
The Taskcluster Github service renders .taskcluster.yml with a `taskcluster_root_url` context. We started relying on this in fxci-config as part of the integration test changes.

However, this broke the `test-build-decision` cron hook, which *doesn't* render .taskcluster.yml with `taskcluster_root_url`. We could simply update our `.taskcluster.yml` to check if the context exists before using it, but IMO we should make the context between the two places (Github service and build-decision) as close to each other as possible.

So let's ensure we're passing `taskcluster_root_url` as context.