### PR TITLE
fix: ensure Azure worker-pools are ordered by location

### DIFF
--- a/src/ciadmin/generate/worker_pools.py
+++ b/src/ciadmin/generate/worker_pools.py
@@ -290,7 +290,7 @@ def get_azure_provider_config(
     tags = config.get("tags", {})
 
     launch_configs = []
-    for location in locations:
+    for location in sorted(locations):
         for vmSize in vmSizes:
             if provider_id == "azure_trusted":
                 subscription_id = azure_config["trusted_subscription"]


### PR DESCRIPTION
This helps ensure `tc-admin diff` stays clean.