### PR TITLE
feat: add xlarge pool for t-linux-docker

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -3078,6 +3078,40 @@ pools:
       regions: [us-central1, us-east1]
       image: ubuntu-2404-headless
       instance_types: []
+  - pool_id: '{pool-group}/t-linux-docker-xlarge'
+    description: Worker for gecko-based automation.
+    owner: release+tc-workers@mozilla.com
+    provider_id: fxci-level1-gcp
+    variants:
+      - pool-group: gecko-t
+    email_on_error: true
+    config:
+      worker-config:
+        genericWorker:
+          config:
+            enableInteractive: true
+            headlessTasks: true
+            disableNativePayloads: true
+            downloadsDir: /home/generic-worker/downloads
+            cachesDir: /home/generic-worker/caches
+      minCapacity: 0
+      maxCapacity:
+        by-pool-group:
+          gecko-t: 2500
+          comm-t: 100
+          mozilla-t: 100
+          nss-t: 100
+      implementation: generic-worker/linux-d2g
+      regions: [us-central1, us-west1]
+      image: ubuntu-2404-headless
+      instance_types:
+        - minCpuPlatform: Intel Cascadelake
+          disks:
+            - <<: *persistent-disk
+              diskSizeGb: 75
+            - *scratch-disk
+            - *scratch-disk
+          machine_type: c2-standard-16
   - pool_id: 'gecko-t/t-linux-docker-kvm'
     description: Worker for gecko-based automation.
     owner: release+tc-workers@mozilla.com


### PR DESCRIPTION
This is needed to run `tgdiff` without OOMing after adding multiprocess support.