### PR TITLE
bump windows images to 1.0.7

### DIFF
--- a/worker-images.yml
+++ b/worker-images.yml
@@ -112,22 +112,22 @@ ronin_b1_windows2022_64_2009_alpha:
     name: win2022_64_2009_alpha
 ronin_b1_windows2022_64_2009:
   azure2:
-    version: 1.0.6
+    version: 1.0.7
     resource_group: rg-packer-worker-images
-    deployment_id: "4791c60"
+    deployment_id: "2bf40ba"
     name: win2022_64_2009
 ronin_b3_windows2022_64_2009:
   azure_trusted:
-    version: 1.0.6
+    version: 1.0.7
     resource_group: rg-packer-worker-images
-    deployment_id: "4791c60"
+    deployment_id: "2bf40ba"
     name: trusted_win2022_64_2009
 # Windows 10
 ronin_t_windows10_64_2009_prod:
   azure2:
-    version: 1.0.6
+    version: 1.0.7
     resource_group: rg-packer-worker-images
-    deployment_id: "4791c60"
+    deployment_id: "2bf40ba"
     name: win10_64_2009
 ronin_t_windows10_64_2009_alpha:
   azure2:
@@ -144,15 +144,15 @@ ronin_b1_windows11_a64_24h2_builder_alpha:
     name: win11_a64_24h2_builder_alpha
 ronin_b1_windows11_a64_24h2_builder:
   azure2:
-    version: 1.0.6
+    version: 1.0.7
     resource_group: rg-packer-worker-images
-    deployment_id: "4791c60"
+    deployment_id: "2bf40ba"
     name: win11_a64_24h2_builder
 ronin_b3_windows11_a64_24h2_builder:
   azure_trusted:
-    version: 1.0.6
+    version: 1.0.7
     resource_group: rg-packer-worker-images
-    deployment_id: "4791c60"
+    deployment_id: "2bf40ba"
     name: trusted_win11_a64_24h2_builder
 ronin_t_windows11_a64_24h2_tester_alpha:
   azure2:
@@ -162,15 +162,15 @@ ronin_t_windows11_a64_24h2_tester_alpha:
     name: win11_a64_24h2_tester_alpha
 ronin_t_windows11_a64_24h2_tester:
   azure2:
-    version: 1.0.6
+    version: 1.0.7
     resource_group: rg-packer-worker-images
-    deployment_id: "4791c60"
+    deployment_id: "2bf40ba"
     name: win11_a64_24h2_tester
 ronin_t_windows11_64_24h2:
   azure2:
-    version: 1.0.6
+    version: 1.0.7
     resource_group: rg-packer-worker-images
-    deployment_id: "4791c60"
+    deployment_id: "2bf40ba"
     name: win11_64_24h2
 ronin_t_windows11_64_24h2_alpha:
   azure2:


### PR DESCRIPTION
- Upgrade 7zip to 25.00
- Remove gpg4win on windows builders
- Upgrade taskcluster binaries to 88.0.5
- Update y:/hg-shared to d:/hg-shared and c:/hg-shared on arm64 machines
- Update windows server 2022 images to windows server core edition