### PR TITLE
revert Windows Image 1.0.7 to 1.0.6 image to address ASAN failures

### DIFF
--- a/worker-images.yml
+++ b/worker-images.yml
@@ -112,22 +112,22 @@ ronin_b1_windows2022_64_2009_alpha:
     name: win2022_64_2009_alpha
 ronin_b1_windows2022_64_2009:
   azure2:
-    version: 1.0.7
+    version: 1.0.6
     resource_group: rg-packer-worker-images
-    deployment_id: "2bf40ba"
+    deployment_id: "4791c60"
     name: win2022_64_2009
 ronin_b3_windows2022_64_2009:
   azure_trusted:
-    version: 1.0.7
+    version: 1.0.6
     resource_group: rg-packer-worker-images
-    deployment_id: "2bf40ba"
+    deployment_id: "4791c60"
     name: trusted_win2022_64_2009
 # Windows 10
 ronin_t_windows10_64_2009_prod:
   azure2:
-    version: 1.0.7
+    version: 1.0.6
     resource_group: rg-packer-worker-images
-    deployment_id: "2bf40ba"
+    deployment_id: "4791c60"
     name: win10_64_2009
 ronin_t_windows10_64_2009_alpha:
   azure2:
@@ -144,15 +144,15 @@ ronin_b1_windows11_a64_24h2_builder_alpha:
     name: win11_a64_24h2_builder_alpha
 ronin_b1_windows11_a64_24h2_builder:
   azure2:
-    version: 1.0.7
+    version: 1.0.6
     resource_group: rg-packer-worker-images
-    deployment_id: "2bf40ba"
+    deployment_id: "4791c60"
     name: win11_a64_24h2_builder
 ronin_b3_windows11_a64_24h2_builder:
   azure_trusted:
-    version: 1.0.7
+    version: 1.0.6
     resource_group: rg-packer-worker-images
-    deployment_id: "2bf40ba"
+    deployment_id: "4791c60"
     name: trusted_win11_a64_24h2_builder
 ronin_t_windows11_a64_24h2_tester_alpha:
   azure2:
@@ -162,15 +162,15 @@ ronin_t_windows11_a64_24h2_tester_alpha:
     name: win11_a64_24h2_tester_alpha
 ronin_t_windows11_a64_24h2_tester:
   azure2:
-    version: 1.0.7
+    version: 1.0.6
     resource_group: rg-packer-worker-images
-    deployment_id: "2bf40ba"
+    deployment_id: "4791c60"
     name: win11_a64_24h2_tester
 ronin_t_windows11_64_24h2:
   azure2:
-    version: 1.0.7
+    version: 1.0.6
     resource_group: rg-packer-worker-images
-    deployment_id: "2bf40ba"
+    deployment_id: "4791c60"
     name: win11_64_24h2
 ronin_t_windows11_64_24h2_alpha:
   azure2:


### PR DESCRIPTION
Tests impacted [here](https://treeherder.mozilla.org/jobs?repo=mozilla-release&group_state=expanded&selectedTaskRun=BtAdBAafQ3u-DT4sU-IS2g.0&resultStatus=testfailed%2Cbusted%2Cexception&revision=e82ff056992f5867431be0f3b25822b778077187) and [here](https://firefox-ci-tc.services.mozilla.com/tasks/ULF9Nd7rRBSM6fkz8aH2Hw).