### PR TITLE
add us-east1 region to */t-linux-docker-noscratch pools

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -3417,7 +3417,7 @@ pools:
           comm-t: 100
           mozilla-t: 100
       implementation: generic-worker/linux-d2g
-      regions: [us-central1, us-west1]
+      regions: [us-central1, us-west1, us-east1]
       image: ubuntu-2404-headless
       instance_types:
         - minCpuPlatform: Intel Cascadelake


### PR DESCRIPTION
To address spot terminations mentioned in https://bugzilla.mozilla.org/show_bug.cgi?id=1984760.