### PR TITLE
Bump maxCapacity for gecko-t/t-linux-docker-kvm (bug 1985290)

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -3305,7 +3305,7 @@ pools:
     provider_id: fxci-level1-gcp
     config:
       minCapacity: 0
-      maxCapacity: 800
+      maxCapacity: 1600
       regions: [us-central1, us-west1]
       image: ubuntu-2404-headless
       implementation: generic-worker/linux-d2g


### PR DESCRIPTION
There's extra load right now on this pool, so bumping the capacity should stop backlogs from building up.