### PR TITLE
fix: use globally shared Github client

### DIFF
--- a/src/ciadmin/check/check_pull_request_policies.py
+++ b/src/ciadmin/check/check_pull_request_policies.py
@@ -8,6 +8,7 @@ from tcadmin.util.sessions import with_aiohttp_session
 
 from ciadmin.generate import tcyml
 from ciadmin.generate.ciconfig.projects import Project
+from ciadmin.util import github
 
 
 async def _get_pull_request_policy(project):
@@ -19,6 +20,7 @@ async def _get_pull_request_policy(project):
             default_branch=project.default_branch,
         )
     )
+    await github.close_client()
     return config.get("policy", {}).get("pullRequests")
 
 

--- a/src/ciadmin/generate/in_tree_actions.py
+++ b/src/ciadmin/generate/in_tree_actions.py
@@ -19,6 +19,7 @@ from tcadmin.util.matchlist import MatchList
 from tcadmin.util.scopes import normalizeScopes
 from tcadmin.util.sessions import aiohttp_session
 
+from ciadmin.util import github
 from ciadmin.util.matching import glob_match
 
 from . import branches, tcyml
@@ -430,6 +431,8 @@ async def update_resources(resources):
                 ),
             )
             resources.add(role)
+
+    await github.close_client()
 
     # download all existing hooks and check the last time they were used
     hooks = Hooks(optionsFromEnvironment(), session=aiohttp_session())

--- a/src/ciadmin/util/github.py
+++ b/src/ciadmin/util/github.py
@@ -1,0 +1,38 @@
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+
+import asyncio
+
+from simple_github import AsyncClient, client_from_env
+
+# Global shared client session
+_client: AsyncClient | None = None
+_client_lock = asyncio.Lock()
+
+
+async def get_client():
+    """Get a shared GitHub client that can be reused across all GitHub API calls.
+
+    This helps avoid resource exhaustion by avoiding creation of hundreds of
+    individual client sessions, each with their own connection pools and DNS
+    resolvers.
+    """
+    global _client, _client_lock
+
+    async with _client_lock:
+        if _client is None:
+            client_cls = client_from_env("mozilla-releng", ["fxci-config"])
+            _client = client_cls()  # type: ignore
+
+    return _client
+
+
+async def close_client():
+    """Cleanup the shared global client."""
+    global _client, _client_lock
+
+    async with _client_lock:
+        if _client is not None:
+            await _client.close()
+            _client = None

--- a/tests/ciadmin/test_generate_tcyml.py
+++ b/tests/ciadmin/test_generate_tcyml.py
@@ -8,6 +8,7 @@ import pytest
 from tcadmin.util.sessions import with_aiohttp_session
 
 from ciadmin.generate import tcyml
+from ciadmin.util import github
 
 # pin a revision of mozilla-central so we know what to expect
 PINNED_REV = "ff8505d177b9"
@@ -17,4 +18,5 @@ PINNED_REV = "ff8505d177b9"
 @with_aiohttp_session
 async def test_get_tcyml():
     res = await tcyml.get("https://hg.mozilla.org/mozilla-central", revision=PINNED_REV)
+    await github.close_client()
     assert hashlib.sha512(res).hexdigest()[:10] == "684648599a"


### PR DESCRIPTION
Previously we were instantiating two SimpleGithub clients for each project. One to get the branches, another to get the .taskcluster.yml.

On my system, creating this many clients (which in turn each create their own aiohttp sessions and DNSResolvers), was triggering a bug in aiodns by surpassing some sort of resource limit:
https://github.com/aio-libs/aiodns/issues/128

I'm not really sure why no one else was hitting this, but using a single shared `SimpleGithub` client across all Github API calls fixes the issue for me and should be faster anyway as we will actually re-use aiohttp sessions.