### PR TITLE
Enable `firefox-ci-playground-private` to use private artifacts (bug 1989274)

### DIFF
--- a/grants.d/grants.yml
+++ b/grants.d/grants.yml
@@ -1052,6 +1052,21 @@
     - project:
         feature: is-trunk
 
+- grant:
+    - queue:get-artifact:private/project/{trust_domain}/*
+  to:
+    - project:
+        feature: private-artifacts
+        job: [action:*, branch:*, cron:*, pull-request:trusted, release:*]
+
+- grant:
+    - queue:get-artifact:private/project/{trust_domain}-{trust_project}/*
+  to:
+    - project:
+        feature: private-artifacts
+        has_trust_project: true
+        job: [action:*, branch:*, cron:*, pull-request:trusted, release:*]
+
 ##
 # mozilla roles
 #

--- a/projects.yml
+++ b/projects.yml
@@ -1151,6 +1151,7 @@ firefox-ci-playground-private:
   trust_project: firefox-ci-playground
   features:
     github-private-repo: true
+    private-artifacts: true
     github-pull-request:
       policy: public
     github-taskgraph: true


### PR DESCRIPTION
Updated diff after first round of comments:

```diff
--- current
+++ generated
@@ -366394,16 +366394,26 @@ Role=repo:github.com/mozilla-releng/firefox-ci-playground-private:*:
       - secrets:get:project/mozilla/firefox-ci-playground/level-1/*
       - secrets:get:project/mozilla/firefox-ci-playground/level-any/*
       - secrets:get:project/mozilla/level-1/*
       - secrets:get:project/mozilla/level-any/*
       - secrets:get:project/releng/releng-github-clone-ssh
       - secrets:get:project/taskcluster/gecko/hgfingerprint
       - secrets:get:project/taskcluster/gecko/hgmointernal

+  Role=repo:github.com/mozilla-releng/firefox-ci-playground-private:action:*:
+    roleId: repo:github.com/mozilla-releng/firefox-ci-playground-private:action:*
+    description:
+      *DO NOT EDIT* - This resource is configured automatically by [ci-admin](https://github.com/mozilla-releng/fxci-config).
+
+      Scopes in this role are defined in [fxci-config/grants.d](https://github.com/mozilla-releng/fxci-config/blob/main/grants.d).
+    scopes:
+      - queue:get-artifact:private/project/mozilla-firefox-ci-playground/*
+      - queue:get-artifact:private/project/mozilla/*
+
   Role=repo:github.com/mozilla-releng/firefox-ci-playground-private:branch:main:
     roleId: repo:github.com/mozilla-releng/firefox-ci-playground-private:branch:main
     description:
       *DO NOT EDIT* - This resource is configured automatically by [ci-admin](https://github.com/mozilla-releng/fxci-config).

       Scopes in this role are defined in [fxci-config/grants.d](https://github.com/mozilla-releng/fxci-config/blob/main/grants.d).
     scopes:
       - docker-worker:cache:mozilla-level-1-*
@@ -366413,16 +366423,18 @@ Role=repo:github.com/mozilla-releng/firefox-ci-playground-private:branch:main:
       - in-tree:hook-action:project-mozilla/in-tree-action-1-*
       - index:insert-task:mozilla.v2.firefox-ci-playground-private.*
       - index:insert-task:mozilla.v2.firefox-ci-playground.cache.level-1.*
       - queue:cancel-task:mozilla-level-1/*
       - queue:create-task:low:built-in/*
       - queue:create-task:low:mozilla-1/*
       - queue:create-task:low:mozilla-t/*
       - queue:create-task:low:releng-hardware/mozilla-b-1-*
+      - queue:get-artifact:private/project/mozilla-firefox-ci-playground/*
+      - queue:get-artifact:private/project/mozilla/*
       - queue:rerun-task:mozilla-level-1/*
       - queue:route:checks
       - queue:route:index.mozilla.v2.firefox-ci-playground-private.*
       - queue:route:index.mozilla.v2.firefox-ci-playground.cache.level-1.*
       - queue:scheduler-id:mozilla-level-1
       - secrets:get:project/mozilla/firefox-ci-playground/level-1/*
       - secrets:get:project/mozilla/firefox-ci-playground/level-any/*
       - secrets:get:project/mozilla/level-1/*
@@ -366441,16 +366453,26 @@ Role=repo:github.com/mozilla-releng/firefox-ci-playground-private:pull-request:
       - index:insert-task:mozilla.v2.firefox-ci-playground-private-pr.*
       - index:insert-task:mozilla.v2.firefox-ci-playground.cache.head.*
       - index:insert-task:mozilla.v2.firefox-ci-playground.cache.pr.*
       - queue:cancel-task-group:mozilla-level-1/*
       - queue:route:index.mozilla.v2.firefox-ci-playground-private-pr.*
       - queue:route:index.mozilla.v2.firefox-ci-playground.cache.head.*
       - queue:route:index.mozilla.v2.firefox-ci-playground.cache.pr.*
       - queue:seal-task-group:mozilla-level-1/*
+
+  Role=repo:github.com/mozilla-releng/firefox-ci-playground-private:release:*:
+    roleId: repo:github.com/mozilla-releng/firefox-ci-playground-private:release:*
+    description:
+      *DO NOT EDIT* - This resource is configured automatically by [ci-admin](https://github.com/mozilla-releng/fxci-config).
+
+      Scopes in this role are defined in [fxci-config/grants.d](https://github.com/mozilla-releng/fxci-config/blob/main/grants.d).
+    scopes:
+      - queue:get-artifact:private/project/mozilla-firefox-ci-playground/*
+      - queue:get-artifact:private/project/mozilla/*

   Role=repo:github.com/mozilla-releng/firefox-ci-playground:*:
     roleId: repo:github.com/mozilla-releng/firefox-ci-playground:*
     description:
       *DO NOT EDIT* - This resource is configured automatically by [ci-admin](https://github.com/mozilla-releng/fxci-config).

       Scopes in this role are defined in [fxci-config/grants.d](https://github.com/mozilla-releng/fxci-config/blob/main/grants.d).
     scopes:

```