### PR TITLE
Fix(worker-pools): Remove us-west1 from c3d pools

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -3071,7 +3071,7 @@ pools:
           mozilla-t: 100
           nss-t: 100
       implementation: generic-worker/linux-d2g
-      regions: [us-central1, us-east1, us-west1]
+      regions: [us-central1, us-east1]
       image: ubuntu-2404-headless
       instance_types: []
   - pool_id: 'gecko-t/t-linux-docker-kvm'


### PR DESCRIPTION
Right now c3d instances are available, but not with lssd. I'm just removing the region for now, and will implement a better system to add lssd to invalid-instances config