### PR TITLE
Bug 1990017 - add mochitest kind to gecko integration tests

### DIFF
--- a/taskcluster/kinds/firefoxci-artifact/kind.yml
+++ b/taskcluster/kinds/firefoxci-artifact/kind.yml
@@ -34,6 +34,7 @@ tasks:
       - gecko.v2.mozilla-central.latest.taskgraph.decision-os-integration
     include-attrs:
       kind:
+        - mochitest
         - source-test
         - startup-test
         - test

--- a/taskcluster/kinds/integration-test/kind.yml
+++ b/taskcluster/kinds/integration-test/kind.yml
@@ -18,6 +18,7 @@ tasks:
       - gecko.v2.mozilla-central.latest.taskgraph.decision-os-integration
     include-attrs:
       kind:
+        - mochitest
         - source-test
         - startup-test
         - test


### PR DESCRIPTION
`mochitest` was split out of the catch-all `test` kind.