### PR TITLE
feat: add new test kinds to os-integration tests (bug 1989652)

### DIFF
--- a/taskcluster/kinds/firefoxci-artifact/kind.yml
+++ b/taskcluster/kinds/firefoxci-artifact/kind.yml
@@ -34,10 +34,13 @@ tasks:
       - gecko.v2.mozilla-central.latest.taskgraph.decision-os-integration
     include-attrs:
       kind:
+        - browsertime
         - mochitest
+        - reftest
         - source-test
         - startup-test
         - test
+        - web-platform-tests
     exclude-attrs:
       test_platform:
         - android-hw

--- a/taskcluster/kinds/integration-test/kind.yml
+++ b/taskcluster/kinds/integration-test/kind.yml
@@ -18,10 +18,13 @@ tasks:
       - gecko.v2.mozilla-central.latest.taskgraph.decision-os-integration
     include-attrs:
       kind:
+        - browsertime
         - mochitest
+        - reftest
         - source-test
         - startup-test
         - test
+        - web-platform-tests
     exclude-attrs:
       test_platform:
         - android-hw


### PR DESCRIPTION
Only `browsertime` actually has os-integration tests at the moment, but AFAICT there's no harm in futureproofing this.