### PR TITLE
fix: grant translations nightly cron run access to upload to developm…

### DIFF
--- a/grants.d/translations.yml
+++ b/grants.d/translations.yml
@@ -32,6 +32,7 @@
           - pull-request:*
           - action:train
           - pr-action:train
+          - cron:run-pipeline
 
 - grant:
     - project:translations:releng:beetmover:bucket:production


### PR DESCRIPTION
…ent bucket

This has been permafailing since automated uploads landed, which has now caused integration tests to fail, because the cron runs are out of date.