### PR TITLE
fix: bump max capacity for `gecko-2/b-linux-medium-gcp`

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -844,6 +844,7 @@ pools:
       maxCapacity:
         by-pool-group:
           gecko-1: 200
+          gecko-2: 50
           gecko-3: 100
           default: 10
       regions: [us-central1, us-west1]


### PR DESCRIPTION
While looking at the pending times dashboard, I noticed we are waiting an average of nearly 2 hours for tasks on this pool.