### PR TITLE
Grant `queue:claimed-count:*` to everyone

### DIFF
--- a/grants.d/grants.yml
+++ b/grants.d/grants.yml
@@ -2865,6 +2865,7 @@
     - queue:list-task-group:*
     - queue:list-worker-types:*
     - queue:list-workers:*
+    - queue:claimed-count:*
     - queue:pending-count:*
     - queue:status:*
     - secrets:list-secrets


### PR DESCRIPTION
We already allow the anonymous role to count pending tasks in a queue, let's add the corresponding scope to count claimed tasks as well.