### PR TITLE
chore(azure): switch vm sku for win10 gpu workload

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -2637,13 +2637,6 @@ pools:
                 west-us: 0.4
                 east-us-2: 0.4
                 default: 0.2
-            Standard_NV12s_v3:
-              by-location:
-                west-us: 1
-                west-us-2: 1
-                east-us: 1
-                east-us-2: 1
-                default: 0.5
             Standard_NV12ads_A10_v5:
               by-location:
                 east-us: 1


### PR DESCRIPTION
Try push: https://treeherder.mozilla.org/jobs?repo=try&revision=a8484e2eed38d1fc799dadecd7d21bc69ad64de8

Microsoft will be deprecating the [current gpu sku](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/gpu-accelerated/nvv3-series-retirement) Sept 2026 and Win10 will be EOL shortly. This is getting ahead of the deprecation of the NVv3 sku deprecation.