### PR TITLE
feat: add northamerica-northeast1 region for b-linux-medium-gcp pool

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -862,7 +862,7 @@ pools:
           gecko-2: 50
           gecko-3: 100
           default: 10
-      regions: [us-central1, us-west1]
+      regions: [us-central1, us-west1, northamerica-northeast1]
       image:
         by-chain-of-trust:
           trusted: monopacker-docker-worker-trusted-current-gcp


### PR DESCRIPTION
It looks like we largely don't use this region due to https://bugzilla.mozilla.org/show_bug.cgi?id=1882320, which says:
> This somewhat stalled out because there are certain instance types that are significantly more expensive in this region. We need some kind of way to control which instance types are allowed in which regions. Maybe just a check in fxci-config is good enough.

The `c2-standard-8` used for this worker type is actually cheaper in this region though...so this concern doesn't apply.