### PR TITLE
raise maxCapacity to 200 for `b-linux-medium-gcp`

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -860,7 +860,7 @@ pools:
         by-pool-group:
           gecko-1: 200
           gecko-2: 50
-          gecko-3: 100
+          gecko-3: 200
           default: 10
       regions: [us-central1, us-west1, northamerica-northeast1]
       image:


### PR DESCRIPTION
I added a new region for these in https://github.com/mozilla-releng/fxci-config/pull/567; we should probably raise the max capacity as well. (It's unclear to me why we'd want `gecko-3` to be lower capacity than `gecko-1`, so I'm raising it to match that.)