### PR TITLE
fix: Raise maxCapacity for level gecko-1/decision-gcp

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -977,7 +977,7 @@ pools:
           default: 0
       maxCapacity:
         by-pool-group:
-          gecko-1: 40
+          gecko-1: 100
           gecko-3: 20
           default: 4
       instance_types:


### PR DESCRIPTION
<img width="4402" height="1805" alt="Screenshot 2025-10-03 at 18-55-32 Worker Pool gecko-1_decision-gcp - FirefoxCI" src="https://github.com/user-attachments/assets/441ef685-6cb2-4780-af74-2e0c001c3fc7" />

40 workers is not enough when there are a bunch of action tasks like retrigger running. This caused this retrigger task to be waiting for 20 minutes and it's not picked up: https://firefox-ci-tc.services.mozilla.com/tasks/IixqrE_-SPaVaWCsn4jkhA