### PR TITLE
Use the shipit project feature rather than giving scopes manually to shipit

### DIFF
--- a/clients.yml
+++ b/clients.yml
@@ -975,7 +975,7 @@ project/releng/scriptworker/v2/pushmsix/prod/firefoxci-comm-3:
     - queue:claim-work:scriptworker-k8s/comm-3-pushmsix
     - queue:worker-id:comm-3-pushmsix/comm-3-pushmsix-*
 project/releng/scriptworker/v2/shipit/dev/firefoxci-gecko-1:
-  description: ''
+  description: 'gecko level 1 nonprod shipit scriptworker'
   scopes:
     - project:releng:services/shipit_api/update_product_channel_version/firefox
     - project:releng:services/shipit_api/add_release/devedition
@@ -990,7 +990,7 @@ project/releng/scriptworker/v2/shipit/dev/firefoxci-gecko-1:
     - queue:claim-work:scriptworker-k8s/gecko-1-shipit-dev
     - queue:worker-id:gecko-1-shipit-dev/gecko-1-shipit-dev-*
 project/releng/scriptworker/v2/shipit/prod/firefoxci-comm-1:
-  description: ''
+  description: 'comm level 1 shipit scriptworker'
   scopes:
     - project:releng:services/shipit_api/update_product_channel_version/thunderbird
     - project:releng:services/shipit_api/rebuild_product_details
@@ -998,7 +998,7 @@ project/releng/scriptworker/v2/shipit/prod/firefoxci-comm-1:
     - queue:claim-work:scriptworker-k8s/comm-1-shipit
     - queue:worker-id:comm-1-shipit/comm-1-shipit-*
 project/releng/scriptworker/v2/shipit/prod/firefoxci-comm-3:
-  description: ''
+  description: 'comm level 3 shipit scriptworker'
   scopes:
     - project:releng:services/shipit_api/update_product_channel_version/thunderbird
     - project:releng:services/shipit_api/rebuild_product_details
@@ -1006,7 +1006,7 @@ project/releng/scriptworker/v2/shipit/prod/firefoxci-comm-3:
     - queue:claim-work:scriptworker-k8s/comm-3-shipit
     - queue:worker-id:comm-3-shipit/comm-3-shipit-*
 project/releng/scriptworker/v2/shipit/prod/firefoxci-gecko-1:
-  description: ''
+  description: 'gecko level 1 shipit scriptworker'
   scopes:
     - project:releng:services/shipit_api/update_product_channel_version/firefox
     - project:releng:services/shipit_api/add_release/devedition
@@ -1021,7 +1021,7 @@ project/releng/scriptworker/v2/shipit/prod/firefoxci-gecko-1:
     - queue:claim-work:scriptworker-k8s/gecko-1-shipit
     - queue:worker-id:gecko-1-shipit/gecko-1-shipit-*
 project/releng/scriptworker/v2/shipit/prod/firefoxci-gecko-3:
-  description: ''
+  description: 'gecko level 3 shipit scriptworker'
   scopes:
     - project:releng:services/shipit_api/update_product_channel_version/firefox
     - project:releng:services/shipit_api/add_release/devedition
@@ -1246,12 +1246,6 @@ project/releng/services/tooltool/bug1604706:
 project/releng/shipit/production:
   description: ''
   scopes:
-    - hooks:trigger-hook:project-comm/in-tree-action-3-generic/*
-    - hooks:trigger-hook:project-comm/in-tree-action-3-release-promotion/*
-    - hooks:trigger-hook:project-gecko/in-tree-action-3-generic/*
-    - hooks:trigger-hook:project-gecko/in-tree-action-3-release-promotion/*
-    - hooks:trigger-hook:project-mobile/in-tree-action-3-generic/*
-    - hooks:trigger-hook:project-mobile/in-tree-action-3-release-promotion/*
     - notify:matrix-room:!tBWwNyfeKqGvkNpdDL:mozilla.org
     - notify:matrix-room:!xPTYfLywxFMryjbnJl:mozilla.org
     - project:releng:services/shipit_api/rebuild_product_details
@@ -1259,12 +1253,6 @@ project/releng/shipit/production:
 project/releng/shipit/staging:
   description: Shipit staging client
   scopes:
-    - hooks:trigger-hook:project-comm/in-tree-action-1-generic/*
-    - hooks:trigger-hook:project-comm/in-tree-action-1-release-promotion/*
-    - hooks:trigger-hook:project-gecko/in-tree-action-1-generic/*
-    - hooks:trigger-hook:project-gecko/in-tree-action-1-release-promotion/*
-    - hooks:trigger-hook:project-mobile/in-tree-action-1-generic/*
-    - hooks:trigger-hook:project-mobile/in-tree-action-1-release-promotion/*
     - notify:matrix-room:!wGgsWXnVncJLSBYmuf:mozilla.org
     - project:releng:services/shipit_api/rebuild_product_details
     - project:releng:services/shipit_api/update_release_status

--- a/projects.yml
+++ b/projects.yml
@@ -104,6 +104,7 @@ mozilla-release:
     treeherder-reporting: true
     trust-domain-scopes: true
     lando: true
+    shipit: true
   cron:
     targets:
       - periodic-update
@@ -123,6 +124,7 @@ comm-release:
     hg-push: true
     treeherder-reporting: true
     trust-domain-scopes: true
+    shipit: true
 mozilla-esr115:
   repo: https://hg.mozilla.org/releases/mozilla-esr115
   lando_repo: firefox-esr115
@@ -140,6 +142,7 @@ mozilla-esr115:
     treeherder-reporting: true
     trust-domain-scopes: true
     lando: true
+    shipit: true
   cron:
     targets:
       - periodic-update
@@ -160,6 +163,7 @@ mozilla-esr128:
     treeherder-reporting: true
     trust-domain-scopes: true
     lando: true
+    shipit: true
   cron:
     targets:
       - periodic-update
@@ -180,6 +184,7 @@ mozilla-esr140:
     treeherder-reporting: true
     trust-domain-scopes: true
     lando: true
+    shipit: true
   cron:
     targets:
       - periodic-update
@@ -199,6 +204,7 @@ comm-esr115:
     hg-push: true
     treeherder-reporting: true
     trust-domain-scopes: true
+    shipit: true
 comm-esr128:
   repo: https://hg.mozilla.org/releases/comm-esr128
   repo_type: hg
@@ -215,6 +221,7 @@ comm-esr128:
     hg-push: true
     treeherder-reporting: true
     trust-domain-scopes: true
+    shipit: true
 comm-esr140:
   repo: https://hg.mozilla.org/releases/comm-esr140
   repo_type: hg
@@ -231,6 +238,7 @@ comm-esr140:
     hg-push: true
     treeherder-reporting: true
     trust-domain-scopes: true
+    shipit: true
 oak:
   repo: https://hg.mozilla.org/projects/oak
   repo_type: hg
@@ -303,6 +311,7 @@ mozilla-beta:
     treeherder-reporting: true
     trust-domain-scopes: true
     lando: true
+    shipit: true
   cron:
     targets:
       - android-l10n-sync
@@ -325,6 +334,7 @@ comm-beta:
     hg-push: true
     treeherder-reporting: true
     trust-domain-scopes: true
+    shipit: true
   cron:
     targets:
       - l10n-bumper
@@ -462,6 +472,7 @@ try:
     treeherder-reporting: true
     trust-domain-scopes: true
     lando: true
+    shipit: true
 try-comm-central:
   repo: https://hg.mozilla.org/try-comm-central
   repo_type: hg
@@ -478,6 +489,7 @@ try-comm-central:
     hg-push: true
     treeherder-reporting: true
     trust-domain-scopes: true
+    shipit: true
 larch:
   repo: https://hg.mozilla.org/projects/larch
   repo_type: hg


### PR DESCRIPTION
While looking at adding more scopes I got confused as to why we only had gecko/comm/mobile in the list of scopes added to the shipit clients. Turns out that those scopes are inferred for other projects using the `shipit` feature. gecko/comm are the only trust domains that did not have a single project with the shipit feature, the mobile scopes were useless. I ended up marking all gecko/comm branches interacting with shipit with the feature (technically we only need on project per trust domain/level but I wanted to avoid the confusion).

The only resulting changes are the description of the clients and that it's going to create a comm-1-dev client.