### PR TITLE
Bug 1992745 - Give shipit scopes to cancel tasks and seal task groups

### DIFF
--- a/clients-interpreted.yml
+++ b/clients-interpreted.yml
@@ -32,6 +32,8 @@
           scopes:
               - hooks:trigger-hook:project-{trust_domain}/in-tree-action-1-generic/*
               - hooks:trigger-hook:project-{trust_domain}/in-tree-action-1-release-promotion/*
+              - queue:cancel-task:project-{trust_domain}-level-1/*
+              - queue:seal-task-group:project-{trust_domain}-level-1/*
   for:
       - project:
             level: 1
@@ -59,6 +61,8 @@
           scopes:
               - hooks:trigger-hook:project-{trust_domain}/in-tree-action-3-generic/*
               - hooks:trigger-hook:project-{trust_domain}/in-tree-action-3-release-promotion/*
+              - queue:cancel-task:project-{trust_domain}-level-3/*
+              - queue:seal-task-group:project-{trust_domain}-level-3/*
   for:
       - project:
             level: 3


### PR DESCRIPTION
We're changing how shipit cancels running tasks to fix an issue where we could end up with tasks that would continue running despite a release being cancelled. For that, shipit needs to be able to call `queue.cancelTask` and `queue.sealTaskGroup` which requires extra scopes.