### PR TITLE
Bug 2024191 - Handle replication lag and skip tags-only hg pushes

### DIFF
--- a/build-decision/src/build_decision/cron/__init__.py
+++ b/build-decision/src/build_decision/cron/__init__.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from requests.exceptions import HTTPError
 
-from ..repository import NoPushesError
+from ..repository import NoPushesError, RetryableError
 from ..util.keyed_by import evaluate_keyed_by
 from ..util.schema import Schema
 from . import action, decision
@@ -36,6 +36,8 @@ def load_jobs(repository, revision):
         if e.response.status_code == 404:
             return {}
         raise
+    except RetryableError:
+        return {}
     _cron_yml_schema.validate(cron_yml)
 
     # resolve keyed_by fields in each job

--- a/build-decision/src/build_decision/hg_push.py
+++ b/build-decision/src/build_decision/hg_push.py
@@ -62,6 +62,10 @@ def build_decision(*, repository, taskcluster_yml_repo, dry_run):
         logger.warning("Push is too old, not triggering tasks")
         return
 
+    if set(push.get("files", [])) == {".hgtags"}:
+        logger.warning("Push only modifies .hgtags, not scheduling decision task")
+        return
+
     with timed("Fetching .taskcluster.yml"):
         if taskcluster_yml_repo is None:
             taskcluster_yml = repository.get_file(".taskcluster.yml", revision=revision)

--- a/build-decision/src/build_decision/repository.py
+++ b/build-decision/src/build_decision/repository.py
@@ -79,10 +79,10 @@ class Repository:
         try:
             res.raise_for_status()
         except requests.HTTPError:
-            if res.status_code == 404 and self.repository_type == "hg":
+            if res.status_code == 404:
                 raise RetryableError(
                     f"Got 404 fetching {url}. The revision may not have "
-                    "replicated to the edge server yet."
+                    "been replicated yet."
                 )
             raise
         return res.text

--- a/build-decision/src/build_decision/repository.py
+++ b/build-decision/src/build_decision/repository.py
@@ -6,6 +6,7 @@ import logging
 
 import attr
 import redo
+import requests
 import yaml
 from requests.exceptions import ChunkedEncodingError, ConnectionError, SSLError
 
@@ -15,6 +16,10 @@ logger = logging.getLogger(__name__)
 
 
 class NoPushesError(Exception):
+    pass
+
+
+class RetryableError(Exception):
     pass
 
 
@@ -66,11 +71,21 @@ class Repository:
         else:
             raise Exception(f"Unknown repository_type {self.repository_type}!")
 
-        res = SESSION.get(url, headers=headers, timeout=60)
-        res.raise_for_status()
-        tcyml = res.text
+        return yaml.safe_load(self._fetch_file(url, headers))
 
-        return yaml.safe_load(tcyml)
+    @redo.retriable(attempts=5, sleeptime=10, retry_exceptions=(RetryableError,))
+    def _fetch_file(self, url, headers):
+        res = SESSION.get(url, headers=headers, timeout=60)
+        try:
+            res.raise_for_status()
+        except requests.HTTPError:
+            if res.status_code == 404 and self.repository_type == "hg":
+                raise RetryableError(
+                    f"Got 404 fetching {url}. The revision may not have "
+                    "replicated to the edge server yet."
+                )
+            raise
+        return res.text
 
     @redo.retriable(
         attempts=5,

--- a/build-decision/src/build_decision/repository.py
+++ b/build-decision/src/build_decision/repository.py
@@ -71,21 +71,34 @@ class Repository:
         else:
             raise Exception(f"Unknown repository_type {self.repository_type}!")
 
-        return yaml.safe_load(self._fetch_file(url, headers))
+        return yaml.safe_load(self._fetch_file(url, headers, revision=revision))
 
     @redo.retriable(attempts=5, sleeptime=10, retry_exceptions=(RetryableError,))
-    def _fetch_file(self, url, headers):
+    def _fetch_file(self, url, headers, revision=None):
         res = SESSION.get(url, headers=headers, timeout=60)
         try:
             res.raise_for_status()
-        except requests.HTTPError:
+        except requests.HTTPError as e:
             if res.status_code == 404:
-                raise RetryableError(
-                    f"Got 404 fetching {url}. The revision may not have "
-                    "been replicated yet."
-                )
+                self._handle_file_not_found(e, url, revision)
             raise
         return res.text
+
+    def _handle_file_not_found(self, http_error, url, revision):
+        if self.repository_type == "hg" and revision:
+            try:
+                rev_res = SESSION.get(
+                    f"{self.repo_url}/json-rev/{revision}", timeout=15
+                )
+            except requests.RequestException as probe_error:
+                logger.warning("json-rev probe failed: %s", probe_error)
+            else:
+                if rev_res.status_code == 200:
+                    raise http_error
+        raise RetryableError(
+            f"Got 404 fetching {url}. The revision may not have "
+            "been replicated yet."
+        )
 
     @redo.retriable(
         attempts=5,

--- a/build-decision/src/build_decision/repository.py
+++ b/build-decision/src/build_decision/repository.py
@@ -96,8 +96,7 @@ class Repository:
                 if rev_res.status_code == 200:
                     raise http_error
         raise RetryableError(
-            f"Got 404 fetching {url}. The revision may not have "
-            "been replicated yet."
+            f"Got 404 fetching {url}. The revision may not have been replicated yet."
         )
 
     @redo.retriable(

--- a/build-decision/src/build_decision/repository.py
+++ b/build-decision/src/build_decision/repository.py
@@ -149,12 +149,14 @@ class Repository:
                     f"Changeset {revision} is not the tip {tip_revision} of the associated push."
                 )
 
+            files = sorted({f for cs in changesets for f in cs.get("files", [])})
             return {
                 "owner": push_info["user"],
                 "pushlog_id": push_id,
                 "pushdate": push_info["date"],
                 "revision": tip_revision,
                 "base_revision": base_revision,
+                "files": files,
             }
         elif self.repository_type == "git":
             if revision:

--- a/build-decision/tests/test_cron.py
+++ b/build-decision/tests/test_cron.py
@@ -3,7 +3,7 @@ import requests.exceptions
 import yaml
 
 import build_decision.cron as cron
-from build_decision.repository import NoPushesError
+from build_decision.repository import NoPushesError, RetryableError
 
 from . import TEST_DATA_DIR
 
@@ -29,6 +29,12 @@ def test_load_jobs_404(mocker):
     fake_repo.get_file.side_effect = requests.exceptions.HTTPError(
         response=fake_response
     )
+    assert cron.load_jobs(fake_repo, "rev") == {}
+
+
+def test_load_jobs_retryable_error(mocker):
+    fake_repo = mocker.MagicMock()
+    fake_repo.get_file.side_effect = RetryableError("retries exhausted")
     assert cron.load_jobs(fake_repo, "rev") == {}
 
 

--- a/build-decision/tests/test_hg_push.py
+++ b/build-decision/tests/test_hg_push.py
@@ -56,33 +56,43 @@ def test_get_revision_from_pulse_message(mocker, pulse_payload, expected):
 
 
 @pytest.mark.parametrize(
-    "push_age, use_tc_yml_repo, dry_run",
+    "push_age, push_files, use_tc_yml_repo, dry_run",
     (
         (
             # Ignore; too old
             hg_push.MAX_TIME_DRIFT + 5000,
+            ["file1.py"],
             False,
             False,
         ),
         (
             # Don't ignore, dry run
             500,
+            ["file1.py"],
             False,
             True,
         ),
         (
             # Don't ignore, use_tc_yml_repo
             1000,
+            ["file1.py"],
             True,
+            False,
+        ),
+        (
+            # Ignore; tags-only push
+            500,
+            [".hgtags"],
+            False,
             False,
         ),
     ),
 )
-def test_build_decision(mocker, push_age, use_tc_yml_repo, dry_run):
+def test_build_decision(mocker, push_age, push_files, use_tc_yml_repo, dry_run):
     """Add coverage for hg_push.build_decision."""
     taskcluster_root_url = "http://taskcluster.local"
     now_timestamp = 1649974668
-    push = {"pushdate": now_timestamp - push_age}
+    push = {"pushdate": now_timestamp - push_age, "files": push_files}
     fake_repo = mocker.MagicMock()
     fake_repo.get_push_info.return_value = push
     fake_tc_yml_repo = mocker.MagicMock()
@@ -103,7 +113,8 @@ def test_build_decision(mocker, push_age, use_tc_yml_repo, dry_run):
 
     hg_push.build_decision(**args)
 
-    if not dry_run and push_age <= hg_push.MAX_TIME_DRIFT:
+    tags_only = set(push_files) == {".hgtags"}
+    if not dry_run and push_age <= hg_push.MAX_TIME_DRIFT and not tags_only:
         fake_task.submit.assert_called_once_with()
 
         mock_render.assert_called_once()
@@ -112,6 +123,7 @@ def test_build_decision(mocker, push_age, use_tc_yml_repo, dry_run):
         assert render_context == {
             "push": {
                 "pushdate": now_timestamp - push_age,
+                "files": push_files,
             },
             "taskcluster_root_url": taskcluster_root_url,
             "tasks_for": "hg-push",

--- a/build-decision/tests/test_repository.py
+++ b/build-decision/tests/test_repository.py
@@ -120,7 +120,7 @@ def test_get_file_hg_retries_on_404(mocker):
         repo.get_file("fake_path")
 
 
-def test_get_file_git_no_retry_on_404(mocker):
+def test_get_file_git_retries_on_404(mocker):
     fake_session = mocker.MagicMock()
     fake_response = mocker.MagicMock()
     fake_response.status_code = 404
@@ -134,7 +134,7 @@ def test_get_file_git_no_retry_on_404(mocker):
         repo_url="https://github.com/org/repo",
         repository_type="git",
     )
-    with pytest.raises(requests.HTTPError):
+    with pytest.raises(repository.RetryableError):
         repo.get_file("fake_path")
 
 

--- a/build-decision/tests/test_repository.py
+++ b/build-decision/tests/test_repository.py
@@ -102,11 +102,10 @@ def test_get_file(mocker, repository_type, repo_url, revision, raises, expected_
         )
 
 
-def test_get_file_hg_retries_on_404(mocker):
-    fake_session = mocker.MagicMock()
+def test_fetch_file_success(mocker):
     fake_response = mocker.MagicMock()
-    fake_response.status_code = 404
-    fake_response.raise_for_status.side_effect = requests.HTTPError("404")
+    fake_response.text = "file content"
+    fake_session = mocker.MagicMock()
     fake_session.get.return_value = fake_response
 
     mocker.patch.object(repository, "SESSION", new=fake_session)
@@ -116,26 +115,132 @@ def test_get_file_hg_retries_on_404(mocker):
         repo_url="https://hg.mozilla.org/fake_repo",
         repository_type="hg",
     )
-    with pytest.raises(repository.RetryableError):
-        repo.get_file("fake_path")
+    result = repo._fetch_file("https://example.com/file", {})
+    assert result == "file content"
 
 
-def test_get_file_git_retries_on_404(mocker):
-    fake_session = mocker.MagicMock()
+def test_fetch_file_non_404_error(mocker):
     fake_response = mocker.MagicMock()
-    fake_response.status_code = 404
-    fake_response.raise_for_status.side_effect = requests.HTTPError("404")
+    fake_response.status_code = 500
+    fake_response.raise_for_status.side_effect = requests.HTTPError("500")
+    fake_session = mocker.MagicMock()
     fake_session.get.return_value = fake_response
 
     mocker.patch.object(repository, "SESSION", new=fake_session)
     mocker.patch.object(redo, "retry", new=fake_redo_retry)
 
     repo = repository.Repository(
+        repo_url="https://hg.mozilla.org/fake_repo",
+        repository_type="hg",
+    )
+    with pytest.raises(requests.HTTPError):
+        repo._fetch_file("https://example.com/file", {})
+
+
+def test_fetch_file_404_delegates(mocker):
+    fake_response = mocker.MagicMock()
+    fake_response.status_code = 404
+    fake_response.raise_for_status.side_effect = requests.HTTPError("404")
+    fake_session = mocker.MagicMock()
+    fake_session.get.return_value = fake_response
+
+    mocker.patch.object(repository, "SESSION", new=fake_session)
+    mocker.patch.object(redo, "retry", new=fake_redo_retry)
+
+    repo = repository.Repository(
+        repo_url="https://hg.mozilla.org/fake_repo",
+        repository_type="hg",
+    )
+    mock_handle = mocker.patch.object(
+        repository.Repository,
+        "_handle_file_not_found",
+        side_effect=repository.RetryableError("lag"),
+    )
+    with pytest.raises(repository.RetryableError):
+        repo._fetch_file("https://example.com/file", {}, revision="rev")
+    mock_handle.assert_called_once()
+
+
+def test_handle_file_not_found_hg_revision_exists(mocker):
+    json_rev_response = mocker.MagicMock()
+    json_rev_response.status_code = 200
+    fake_session = mocker.MagicMock()
+    fake_session.get.return_value = json_rev_response
+
+    mocker.patch.object(repository, "SESSION", new=fake_session)
+
+    repo = repository.Repository(
+        repo_url="https://hg.mozilla.org/fake_repo",
+        repository_type="hg",
+    )
+    original_error = requests.HTTPError("404")
+    with pytest.raises(requests.HTTPError) as exc_info:
+        repo._handle_file_not_found(original_error, "https://example.com/file", "rev")
+    assert exc_info.value is original_error
+
+
+def test_handle_file_not_found_hg_revision_not_replicated(mocker):
+    json_rev_response = mocker.MagicMock()
+    json_rev_response.status_code = 404
+    fake_session = mocker.MagicMock()
+    fake_session.get.return_value = json_rev_response
+
+    mocker.patch.object(repository, "SESSION", new=fake_session)
+
+    repo = repository.Repository(
+        repo_url="https://hg.mozilla.org/fake_repo",
+        repository_type="hg",
+    )
+    with pytest.raises(repository.RetryableError):
+        repo._handle_file_not_found(
+            requests.HTTPError("404"), "https://example.com/file", "rev"
+        )
+
+
+def test_handle_file_not_found_hg_probe_fails(mocker):
+    fake_session = mocker.MagicMock()
+    fake_session.get.side_effect = requests.ConnectionError("probe failed")
+
+    mocker.patch.object(repository, "SESSION", new=fake_session)
+
+    repo = repository.Repository(
+        repo_url="https://hg.mozilla.org/fake_repo",
+        repository_type="hg",
+    )
+    with pytest.raises(repository.RetryableError):
+        repo._handle_file_not_found(
+            requests.HTTPError("404"), "https://example.com/file", "rev"
+        )
+
+
+def test_handle_file_not_found_hg_no_revision(mocker):
+    fake_session = mocker.MagicMock()
+    mocker.patch.object(repository, "SESSION", new=fake_session)
+
+    repo = repository.Repository(
+        repo_url="https://hg.mozilla.org/fake_repo",
+        repository_type="hg",
+    )
+    with pytest.raises(repository.RetryableError):
+        repo._handle_file_not_found(
+            requests.HTTPError("404"), "https://example.com/file", None
+        )
+    fake_session.get.assert_not_called()
+
+
+def test_handle_file_not_found_git(mocker):
+    fake_session = mocker.MagicMock()
+    mocker.patch.object(repository, "SESSION", new=fake_session)
+
+    repo = repository.Repository(
         repo_url="https://github.com/org/repo",
         repository_type="git",
     )
     with pytest.raises(repository.RetryableError):
-        repo.get_file("fake_path")
+        repo._handle_file_not_found(
+            requests.HTTPError("404"), "https://example.com/file", "rev"
+        )
+    fake_session.get.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/build-decision/tests/test_repository.py
+++ b/build-decision/tests/test_repository.py
@@ -1,5 +1,6 @@
 import pytest
 import redo
+import requests
 import yaml
 
 import build_decision.repository as repository
@@ -99,6 +100,42 @@ def test_get_file(mocker, repository_type, repo_url, revision, raises, expected_
         fake_session.get.assert_called_with(
             expected_url, headers=expected_headers, timeout=60
         )
+
+
+def test_get_file_hg_retries_on_404(mocker):
+    fake_session = mocker.MagicMock()
+    fake_response = mocker.MagicMock()
+    fake_response.status_code = 404
+    fake_response.raise_for_status.side_effect = requests.HTTPError("404")
+    fake_session.get.return_value = fake_response
+
+    mocker.patch.object(repository, "SESSION", new=fake_session)
+    mocker.patch.object(redo, "retry", new=fake_redo_retry)
+
+    repo = repository.Repository(
+        repo_url="https://hg.mozilla.org/fake_repo",
+        repository_type="hg",
+    )
+    with pytest.raises(repository.RetryableError):
+        repo.get_file("fake_path")
+
+
+def test_get_file_git_no_retry_on_404(mocker):
+    fake_session = mocker.MagicMock()
+    fake_response = mocker.MagicMock()
+    fake_response.status_code = 404
+    fake_response.raise_for_status.side_effect = requests.HTTPError("404")
+    fake_session.get.return_value = fake_response
+
+    mocker.patch.object(repository, "SESSION", new=fake_session)
+    mocker.patch.object(redo, "retry", new=fake_redo_retry)
+
+    repo = repository.Repository(
+        repo_url="https://github.com/org/repo",
+        repository_type="git",
+    )
+    with pytest.raises(requests.HTTPError):
+        repo.get_file("fake_path")
 
 
 @pytest.mark.parametrize(

--- a/build-decision/tests/test_repository.py
+++ b/build-decision/tests/test_repository.py
@@ -320,7 +320,9 @@ def test_hg_push_info(mocker, branch, revision, pushes, raises, expected):
                 1: {
                     "user": "me",
                     "date": "now",
-                    "changesets": [{"node": "rev", "parents": ["baserev"], "files": ["file1.py"]}],
+                    "changesets": [
+                        {"node": "rev", "parents": ["baserev"], "files": ["file1.py"]}
+                    ],
                 }
             }
         }

--- a/build-decision/tests/test_repository.py
+++ b/build-decision/tests/test_repository.py
@@ -281,6 +281,7 @@ def test_handle_file_not_found_git(mocker):
                 "pushdate": "now",
                 "revision": "rev",
                 "base_revision": "baserev",
+                "files": ["file1.py"],
             },
         ),
         (
@@ -289,7 +290,10 @@ def test_handle_file_not_found_git(mocker):
             {
                 "pushes": {
                     "1": {
-                        "changesets": [{"parents": ["baserev"]}, {"node": "rev"}],
+                        "changesets": [
+                            {"parents": ["baserev"], "files": ["a.py"]},
+                            {"node": "rev", "files": ["b.py"]},
+                        ],
                         "user": "me",
                         "date": "now",
                     }
@@ -302,6 +306,7 @@ def test_handle_file_not_found_git(mocker):
                 "pushdate": "now",
                 "revision": "rev",
                 "base_revision": "baserev",
+                "files": ["a.py", "b.py"],
             },
         ),
     ),
@@ -315,7 +320,7 @@ def test_hg_push_info(mocker, branch, revision, pushes, raises, expected):
                 1: {
                     "user": "me",
                     "date": "now",
-                    "changesets": [{"node": "rev", "parents": ["baserev"]}],
+                    "changesets": [{"node": "rev", "parents": ["baserev"], "files": ["file1.py"]}],
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Parts 1–3: Add exponential backoff and retry logic to `get_file()` for both hg and git repos. For hg, probe `json-rev/{revision}` on 404 to distinguish genuine missing files (stop retrying) from replication lag (keep retrying).
- Part 4: Include the list of changed files in hg push info by collecting them from all changesets in the push.
- Part 5: Skip scheduling a decision task when the push only modifies `.hgtags` (tag-only pushes don't need a CI run).

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=2024191

## Verification

### `51db26e` — part 1: Add exponential backoff to get_file()
### `3d0d04b` — part 2: Retry get_file() on 404 for git repos too
### `bd5fd0f` — part 3: Probe json-rev on hg 404 to distinguish missing file from replication lag

Simulated replication lag locally against real hg.mozilla.org using a non-existent revision. Observed 5 retry attempts with exponential backoff, each firing the json-rev probe:

```
DEBUG - attempt 1/5 ... RetryableError: Got 404 fetching .../raw-file/deadbeef.../.taskcluster.yml. The revision may not have been replicated yet.
DEBUG - sleeping for 1.16s (attempt 1/5)
...
DEBUG - attempt 5/5 ... RetryableError: ...
INFO - retry: Giving up on _fetch_file
```

Simulated "file genuinely missing" (real revision, non-existent path). json-rev probe returned 200, original HTTPError raised immediately without retry:

```
GET /raw-file/32f9ea6.../nonexistent.yml → 404
GET /json-rev/32f9ea6... → 200
Raised: HTTPError: 404 Client Error: Not Found
```

### `48a3009` — part 4: Include files in hg push info
### `7e90ec3` — part 5: Skip decision task for tags-only hg pushes

Dry-run against real mozilla-central pushes:

Normal push (`32f9ea6`, files: `browser/app/profile/firefox.js`, ...):
```
INFO - Fetching push info took: 1.4
INFO - Fetching .taskcluster.yml took: 5.0
INFO - Rendering task took: 0.0
INFO - Decision Task: { ... rendered task JSON ... }
```

Tags-only push (`e91cfa2`, files: `['.hgtags']`):
```
INFO - Fetching push info took: 1.4
WARNING - Push only modifies .hgtags, not scheduling decision task
```

### All parts — build-decision image test

Per the [build-decision test docs](https://moz-releng-docs.readthedocs.io/en/latest/how-to/test/build-decision.html), fired the [test-build-decision hook](https://firefox-ci-tc.services.mozilla.com/hooks/project-releng/cron-task-mozilla-releng-fxci-config%2Ftest-build-decision) with the image built from this PR. The hook [successfully created a Decision task](https://firefox-ci-tc.services.mozilla.com/tasks/d3qrANP0Q7-TGUiiF1S7kQ):

```
[taskcluster 2026-03-25 17:10:12.639Z] Image 'public/image.tar.zst' from task 'TUkyUBtMQ26ofn7ffq0goA' loaded.  Using image ID sha256:8ef257b040790d82b84a66627c7f266ffe337dcb8fb89c4d087741900e720b10.
[taskcluster 2026-03-25 17:10:12.799Z] === Task Starting ===
2026-03-25 17:10:14,884 - INFO - force-running cron job "test-build-decision"
2026-03-25 17:10:15,051 - INFO - Decision Task: { ... }
2026-03-25 17:10:15,051 - INFO - Task Id: Q8FF7d-kSQSmlQSFDuokqQ
[taskcluster 2026-03-25 17:10:15.477Z] Successful task run with exit code: 0 completed in 3.448 seconds
```