### PR TITLE
Bug 2025695 - xpi-manifest: add lando support for extension_manifest_version_bump

### DIFF
--- a/grants.d/grants.yml
+++ b/grants.d/grants.yml
@@ -2278,6 +2278,7 @@
         alias: [mozilla-beta, mozilla-release, mozilla-esr115, mozilla-esr140]
         job: action:release-promotion
 
+
 # merge day scopes are a bit weird; some repositories update themselves and
 # others, while some only update themselves.
 # TODO: replace the singular `merge_day` action with behaviour-specific scopes

--- a/grants.d/xpi.yml
+++ b/grants.d/xpi.yml
@@ -95,3 +95,20 @@
     - groups:
         - team_moco
         - team_mozillaonline
+
+# Bug 2025695: lando scopes for newtab XPI version bump
+- grant:
+    - project:releng:lando:action:extension_manifest_version_bump
+    - project:releng:lando:repo:firefox-main
+  to:
+    - project:
+        alias: xpi-manifest
+        job: action:release-promotion
+
+- grant:
+    - project:releng:lando:action:extension_manifest_version_bump
+    - project:releng:lando:repo:staging-firefox-main
+  to:
+    - project:
+        alias: staging-xpi-manifest
+        job: action:release-promotion

--- a/projects.yml
+++ b/projects.yml
@@ -1243,6 +1243,7 @@ xpi-manifest:
     taskgraph-cron: true
     beetmover: true
     beetmover-get-artifact-scope: true
+    lando: true
 
 staging-xpi-manifest:
   repo: https://github.com/mozilla-releng/staging-xpi-manifest
@@ -1261,6 +1262,7 @@ staging-xpi-manifest:
     taskgraph-cron: true
     beetmover: true
     beetmover-get-artifact-scope: true
+    lando: true
 
 staging-xpi-public:
   repo: https://github.com/mozilla-releng/staging-xpi-public


### PR DESCRIPTION
[Bug 2025695](https://bugzilla.mozilla.org/show_bug.cgi?id=2025695)

## Summary

- Adds `lando: true` to the `xpi-manifest` and `staging-xpi-manifest` projects
- Grants `project:releng:lando:action:extension_manifest_version_bump` + repo scopes via `grants.d/xpi.yml`
- Creates TC client entries for `xpi-3-lando` and `xpi-1-lando-dev` worker pools (via `clients-interpreted.yml`)

## Merge order

1. **This PR** — merged ✓
2. mozilla-releng/fxci-config [#933](https://github.com/mozilla-releng/fxci-config/pull/933) — merged ✓
3. mozilla-services/cloudops-infra [#6835](https://github.com/mozilla-services/cloudops-infra/pull/6835) (dev) — merged ✓
4. mozilla-services/cloudops-infra [#6848](https://github.com/mozilla-services/cloudops-infra/pull/6848) (chart secret) — merged ✓
5. k8s-sops: dev worker secrets — done ✓
6. mozilla-releng/k8s-autoscale [#264](https://github.com/mozilla-releng/k8s-autoscale/pull/264) (dev) — merged ✓
7. mozilla-releng/scriptworker-scripts [#1413](https://github.com/mozilla-releng/scriptworker-scripts/pull/1413) — merged ✓
8. mozilla-services/cloudops-infra [#6838](https://github.com/mozilla-services/cloudops-infra/pull/6838) (prod) — merged ✓
9. k8s-sops: prod worker secrets — manual step
10. mozilla-releng/k8s-autoscale [#266](https://github.com/mozilla-releng/k8s-autoscale/pull/266) (prod) — merged ✓
11. mozilla-releng/fxci-config [#979](https://github.com/mozilla-releng/fxci-config/pull/979) — fix production lando action scope — merged ✓
12. mozilla-extensions/xpi-manifest [#271](https://github.com/mozilla-extensions/xpi-manifest/pull/271) — merged ✓

## Verification

All verifications were done locally. `ci-admin diff --environment firefoxci` showed the expected new clients and role changes.