### PR TITLE
Bug 2028174 - Add static client for Enterprise console backend artifact access

### DIFF
--- a/clients.yml
+++ b/clients.yml
@@ -282,6 +282,11 @@ project/autophone/gecko-t-lambda-test-3:
     - auth:websocktunnel-token:firefoxcitc/lambda.*
     - queue:claim-work:proj-autophone/gecko-t-lambda-test-3
     - queue:worker-id:lambda/*
+project/enterprise/enterprise-console-backend/dev/artifact-access:
+  description: Static client for Firefox Enterprise to programmatically access private
+    enterprise artifacts.
+  scopes:
+    - queue:get-artifact:project/enterprise/*
 project/packet/docker-worker:
   description: ''
   scopes:


### PR DESCRIPTION
[Bug 2028174](https://bugzilla.mozilla.org/show_bug.cgi?id=2028174)

## Verification

### `b53e95e` — Bug 2028174 - Add static client for Enterprise console backend artifact access

- `ci-admin diff --environment firefoxci`
  ```diff
  @@ -1069,16 +1069,24 @@ Client=project/autophone/gecko-t-lambda-test-3:
        Lambdatest pool for Relops testing of various things.
      scopes:
        - auth:sentry:tc-worker-script
        - auth:statsum:tc-worker-script
        - auth:webhooktunnel
        - auth:websocktunnel-token:firefoxcitc/lambda.*
        - queue:claim-work:proj-autophone/gecko-t-lambda-test-3
        - queue:worker-id:lambda/*
  +
  +  Client=project/enterprise/enterprise-console-backend/dev/artifact-access:
  +    clientId: project/enterprise/enterprise-console-backend/dev/artifact-access
  +    description:
  +      *DO NOT EDIT* - This resource is configured automatically by [ci-admin](https://github.com/mozilla-releng/fxci-config).
  +
  +      Static client for Firefox Enterprise to programmatically access private enterprise artifacts.
  +    scopes: - queue:get-artifact:project/enterprise/*
  
    Client=project/mozci/sheriff-automation:
  ```