### PR TITLE
Use separate resource group per worker pool in Azure

### DIFF
--- a/src/ciadmin/generate/worker_pools.py
+++ b/src/ciadmin/generate/worker_pools.py
@@ -5,6 +5,7 @@
 import copy
 import hashlib
 import json
+import re
 
 import attr
 from tcadmin.resources import WorkerPool
@@ -110,6 +111,15 @@ def _normalize_arm_parameters(parameters):
     }
 
 
+def _sanitize_pool_id_for_rg(pool_id):
+    """Sanitize a pool_id for use in an Azure resource group name.
+
+    Azure RG names: max 90 chars, alphanumeric, hyphens, underscores, periods,
+    parentheses. Pool IDs contain '/' which must be replaced.
+    """
+    return re.sub(r"[^a-zA-Z0-9\-_.]", "-", pool_id)
+
+
 def _build_arm_template_launch_config(
     *,
     pool_id,
@@ -171,11 +181,17 @@ def _build_arm_template_launch_config(
         "parameters": parameters,
     }
 
+    sanitized_pool = _sanitize_pool_id_for_rg(pool_id)
+    arm_resource_group = f"rg-tc-{sanitized_pool}"
+    # Azure RG names max 90 chars
+    arm_resource_group = arm_resource_group[:90]
+
     launch_config = {
         "location": loc,
         "tags": merge(tags),
         "workerConfig": merge(worker_config),
         "armDeployment": arm_deployment,
+        "armDeploymentResourceGroup": arm_resource_group,
         "workerManager": merge(worker_manager_config),
     }
 

--- a/tests/ciadmin/test_generate_worker_pools.py
+++ b/tests/ciadmin/test_generate_worker_pools.py
@@ -262,6 +262,8 @@ def assert_azure_arm(pool):
         "vmSize": {"value": "Standard_F8s_v2"},
     }
 
+    assert launch_config["armDeploymentResourceGroup"] == "rg-tc-provId-my-worker-pool"
+
     assert "hardwareProfile" not in launch_config
     assert "storageProfile" not in launch_config
 


### PR DESCRIPTION
Fixes: https://github.com/taskcluster/taskcluster/issues/8387 Currently every deployment is being applied to the default resource group, which leads to occasional "800 max deployments" limit during spikes of activity.
By using separate resource groups the chances of hitting those limits are significantly lower (unless we request 800+ workers at once in a single pool)

Resource group names are generated as `rg-tc-wp-name` and truncated at 90 chars

W-m is already ensuring those RGs are created if they don't exist