### PR TITLE
Improve fxci-config documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,38 @@
+# fxci-config
+
+## YAML files
+
+Each YAML file in the repo root begins with a comment describing its purpose and schema.
+Read that comment before adding or modifying entries. Key files:
+
+- `clients.yml` — static Taskcluster clients (see header)
+- `clients-interpreted.yml` — templated clients expanded per trust domain (see header)
+- `grants.d/grants.yml` — shared grant definitions (see header for format); per-trust-domain grants live in
+  `grants.d/<trust-domain>.yml`
+- `projects.yml` — project/repository definitions (see header)
+- `worker-pools.yml` — worker pool definitions (see header)
+- `environments.yml` — `firefoxci` (production) and `staging` environment configs
+
+## Workflow
+
+1. Make changes in a local clone.
+2. Determine which environment applies (options in `environments.yml`; usually `firefoxci`).
+3. Run `tc-admin diff --environment=firefoxci` and `tc-admin check --environment=firefoxci`.
+4. Submit for review — changes auto-apply to `firefoxci` (production) on landing.
+
+For staging: comment `/taskcluster apply-staging` on the PR to apply, or run
+`tc-admin apply --environment=staging` locally. Validate against staging first when
+touching scopes, worker configs, or fxci-config itself.
+
+## Verification
+
+Before committing, run `tc-admin diff` to preview the Taskcluster resources that would
+change. You need Taskcluster credentials with `auth:list-clients` scope and a GitHub
+token to avoid rate limits (see `README.md` "Initial Setup" for `GITHUB_TOKEN`).
+
+```bash
+TASKCLUSTER_ROOT_URL=https://firefox-ci-tc.services.mozilla.com \
+  taskcluster signin --scope auth:list-clients > $TMPDIR/tc-creds.sh
+source $TMPDIR/tc-creds.sh
+GITHUB_TOKEN=$(gh auth token) uv run tc-admin diff --environment firefoxci
+```

--- a/README.md
+++ b/README.md
@@ -107,8 +107,19 @@ to specific changes.
      the resources to be modified (much shorter!)
    * `tc-admin check --environment=firefoxci`
 
-1. Submit changes to Phabricator for review.  On landing, the changes will be
-   applied automaticallyi.
+1. Submit changes for review. On landing, changes are automatically applied to
+   the **`firefoxci`** (production) environment only.
+
+## Staging Environment
+
+The `staging` environment is validated (via `tc-admin check`) on every PR and push,
+but is **not** automatically applied. To apply changes to staging:
+
+* Comment `/taskcluster apply-staging` on your pull request, **or**
+* Run locally: `tc-admin apply --environment=staging`
+
+When testing changes that affect scopes, worker configs, or fxci-config itself,
+validate against staging before production.
 
 To apply changes locally (not recommended):
 

--- a/clients.yml
+++ b/clients.yml
@@ -1,4 +1,21 @@
 ---
+# This file contains static Taskcluster client definitions for Firefox CI.
+#
+# Structure
+# ---------
+#
+# Each client is keyed by its clientId. The value is an object with:
+#
+# - `description` -- human-readable description of the client's purpose
+# - `scopes` -- list of Taskcluster scopes granted to this client
+# - `environments` -- (optional) list of environments this client applies to,
+#                     e.g. `[staging]`. Omit to apply to all environments.
+#
+# Entries are sorted alphabetically by clientId.
+#
+# For clients whose clientId or scopes depend on a project's trust domain,
+# see `clients-interpreted.yml` instead.
+
 project/autophone/bitbar-x-test-1:
   description: Bitbar client for testing new docker images and other changes. Should
     only be used by RelOps.


### PR DESCRIPTION
Found these gaps while working on https://github.com/mozilla-releng/fxci-config/pull/921. Claude had some trouble to one-shot the simple addition of a TC client. This documentation aims at improving the next iterations. 

## Summary

- Add schema header to `clients.yml` (the only YAML file without inline docs)
- Document staging deployment flow in README (auto-applied to production only, staging requires explicit apply)
- Add `CLAUDE.md` with CI workflow guidance and PR template for AI agents