### PR TITLE
Bug 2030733 - Implement a new `git-push` tasks_for

### DIFF
--- a/build-decision/src/build_decision/cli.py
+++ b/build-decision/src/build_decision/cli.py
@@ -64,6 +64,18 @@ def hg_push(options):
     )
 
 
+@app.command("git-push", help="Create a git-push decision task.")
+@repo_arguments(app)
+@app.argument("--dry-run", action="store_true")
+def git_push(options):
+    from .git_push import build_decision  # noqa: PLC0415
+
+    build_decision(
+        repository=options["repository"],
+        dry_run=options["dry_run"],
+    )
+
+
 @app.command("cron", help="Process `.cron.yml`.")
 @repo_arguments(app)
 @app.argument("--branch")

--- a/build-decision/src/build_decision/git_push.py
+++ b/build-decision/src/build_decision/git_push.py
@@ -1,0 +1,45 @@
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+
+import json
+import logging
+import os
+
+from .decision import render_tc_yml
+
+logger = logging.getLogger(__name__)
+
+
+def build_decision(*, repository, dry_run):
+    logging.info("Running build-decision task")
+
+    payload = json.loads(os.environ["HOOK_PAYLOAD"])
+    logger.info("Hook Payload:\n%s", json.dumps(payload, indent=4, sort_keys=True))
+
+    event = {
+        "after": payload["sha"],
+        "base_ref": payload.get("base_ref"),
+        "before": payload["base_sha"],
+        "pusher": {"email": payload["owner"]},
+        "ref": payload["ref"],
+        "repository": {
+            "name": repository.repo_path.split("/")[-1],
+            "full_name": repository.repo_path,
+            "html_url": repository.repo_url,
+            "clone_url": repository.repo_url.rstrip("/") + ".git",
+        },
+    }
+
+    tc_yml = repository.get_file(".taskcluster.yml", revision=event["after"])
+
+    task = render_tc_yml(
+        tc_yml,
+        taskcluster_root_url=os.environ["TASKCLUSTER_ROOT_URL"],
+        tasks_for="git-push",
+        event=event,
+    )
+
+    task.display()
+    if not dry_run:
+        task.submit()

--- a/build-decision/tests/test_git_push.py
+++ b/build-decision/tests/test_git_push.py
@@ -1,0 +1,74 @@
+import json
+import os
+
+import pytest
+
+import build_decision.git_push as git_push
+
+HOOK_PAYLOAD = {
+    "base_ref": None,
+    "base_sha": "def456abc123def456abc123def456abc123def4",
+    "owner": "dev@example.com",
+    "ref": "refs/heads/main",
+    "sha": "abc123def456abc123def456abc123def456abc1",
+}
+
+
+@pytest.mark.parametrize(
+    "dry_run",
+    (
+        True,
+        False,
+    ),
+)
+def test_build_decision(mocker, dry_run):
+    """Add coverage for git_push.build_decision."""
+    taskcluster_root_url = "http://taskcluster.local"
+
+    fake_repo = mocker.MagicMock()
+    fake_repo.repo_url = "https://github.com/mozilla-releng/fxci-config"
+    fake_repo.repo_path = "mozilla-releng/fxci-config"
+    fake_task = mocker.MagicMock()
+
+    mocker.patch.object(
+        os,
+        "environ",
+        new={
+            "TASKCLUSTER_ROOT_URL": taskcluster_root_url,
+            "HOOK_PAYLOAD": json.dumps(HOOK_PAYLOAD),
+        },
+    )
+    mock_render = mocker.patch.object(git_push, "render_tc_yml", return_value=fake_task)
+
+    git_push.build_decision(
+        repository=fake_repo,
+        dry_run=dry_run,
+    )
+
+    fake_repo.get_file.assert_called_once_with(
+        ".taskcluster.yml",
+        revision=HOOK_PAYLOAD["sha"],
+    )
+
+    mock_render.assert_called_once()
+    render_kwargs = mock_render.call_args[1]
+    assert render_kwargs["taskcluster_root_url"] == taskcluster_root_url
+    assert render_kwargs["tasks_for"] == "git-push"
+    assert render_kwargs["event"] == {
+        "ref": "refs/heads/main",
+        "before": HOOK_PAYLOAD["base_sha"],
+        "after": HOOK_PAYLOAD["sha"],
+        "base_ref": None,
+        "pusher": {"email": "dev@example.com"},
+        "repository": {
+            "name": "fxci-config",
+            "full_name": "mozilla-releng/fxci-config",
+            "html_url": "https://github.com/mozilla-releng/fxci-config",
+            "clone_url": "https://github.com/mozilla-releng/fxci-config.git",
+        },
+    }
+
+    if dry_run:
+        fake_task.submit.assert_not_called()
+    else:
+        fake_task.submit.assert_called_once_with()

--- a/git-push-template.yml
+++ b/git-push-template.yml
@@ -1,0 +1,72 @@
+---
+# This is the template for the task definition for git push hooks.  Its job is
+# to run a decision task for the given revision of the given repository.
+#
+# This is rendered with JSON-e to create a JSON-e task template in a hook,
+# meaning that the content of this file is rendered *twice* with JSON-e.  The
+# context values for the first rendering are:
+#
+#  - level -- branch level
+#  - trust_domain -- project's trust domain
+#  - hookGroupId / hookId -- hook identifiers
+#  - project_repo -- repository URL
+#  - project_role_prefix -- role prefix for the project
+#  - alias -- project alias
+#
+# Uses of `$${..}` and `$$..: ..` are intended to occur in the second rendering.
+# The context for the second rendering is that provided by the hooks service in
+# response to a triggerHook call with the trigger schema payload.
+
+provisionerId: infra
+workerType: build-decision
+schedulerId: ${trust_domain}-level-${level}
+
+# The "$fromNow" options here are escaped so that they are processed by the hooks service's
+# JSON-e rendering when the hook is fired.
+deadline: {$$fromNow: 30 minutes}
+expires: {$$fromNow: 3 days}
+scopes:
+  - assume:${project_role_prefix}:branch:*
+routes:
+  - index.git-push.v1.${alias}.revision.$${payload.commit_sha}
+payload:
+  # built by pushes to the fxci-config repository
+  image: mozillareleases/build-decision:bd900d7a313c796d48da21fdb54ae35db812e3dc@sha256:2a7e477efee5e8b356ea3b642e30b3b5cb48ffe81b0e72bb223b4522b59345d5
+  env:
+    # pass along the hook trigger payload
+    HOOK_PAYLOAD: {$$json: {$$eval: payload}}
+  command:
+    $flatten:
+      - git-push
+      # hard-coded values that can't be changed by the hook payload
+      - --repo-url
+      - ${project_repo}
+      - --project
+      - ${alias}
+      - --level
+      - ${level}
+      - --trust-domain
+      - ${trust_domain}
+      - --repository-type
+      - git
+  features:
+    taskclusterProxy: true
+
+    # If this task does not succeed immediately, something is probably wrong.  We want to avoid a storm of
+    # decision tasks when that problem is resolved, so we are conservative with the time it can possibly retry
+  maxRunTime: 600
+metadata:
+  $$let:
+    description:
+      $$if: firedBy == "triggerHook"
+      then: Fired by triggerHook call from $${clientId}
+      else: Fired by $${firedBy}
+  in:
+    owner: mozilla-taskcluster-maintenance@mozilla.com
+    source: https://firefox-ci-tc.services.mozilla.com/hooks/${hookGroupId}/${hookId}
+    description: $${description}
+    name: On-Push task for ${project_repo}
+priority: highest
+retries: 5
+tags: {}
+extra: {}

--- a/projects.yml
+++ b/projects.yml
@@ -632,6 +632,7 @@ enterprise-firefox-try:
       level: 1
   features:
     gecko-roles: true
+    git-push: true
     github-taskgraph: true
     github-pull-request:
       policy: collaborators

--- a/projects.yml
+++ b/projects.yml
@@ -27,6 +27,7 @@
 #   - 'is-trunk' -- Branches containing 'landed' code destined for nightly builds. These branches have a shared index
 #       that can be referenced by the tip revision on any push.
 #   - `hg-push` -- decision tasks run for pushes to this hg project's repository
+#   - `git-push` -- decision tasks run for pushes to this git project's repository
 #   - `gecko-roles` -- this repository should have gecko-related roles assigned (for users, actions, cron, etc.)
 #   - `mobile-roles` -- this repository should have https://github.com/mozilla-mobile roles assigned (for users, actions, cron, etc.)
 #   - `xpi-roles` -- this repository should have xpi roles assigned (for users, actions, cron, etc.)

--- a/src/ciadmin/boot.py
+++ b/src/ciadmin/boot.py
@@ -14,6 +14,7 @@ from ciadmin import modify
 from ciadmin.generate import (
     clients,
     cron_tasks,
+    git_pushes,
     grants,
     hg_pushes,
     hooks,
@@ -25,6 +26,7 @@ from ciadmin.generate import (
 RESOURCES = {
     "clients": clients.update_resources,
     "cron_tasks": cron_tasks.update_resources,
+    "git_pushes": git_pushes.update_resources,
     "grants": grants.update_resources,
     "hg_pushes": hg_pushes.update_resources,
     "hooks": hooks.update_resources,

--- a/src/ciadmin/generate/git_pushes.py
+++ b/src/ciadmin/generate/git_pushes.py
@@ -1,0 +1,107 @@
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+
+import textwrap
+
+import jsone
+from tcadmin.resources import Hook, Role
+
+from .ciconfig.get import get_ciconfig_file
+from .ciconfig.projects import Project
+
+
+async def make_hook(project: Project, branch) -> Hook:
+    hookGroupId = "git-push"
+    hookId = f"{project.role_prefix.removeprefix('repo:')}:branch:{branch.name}"
+
+    task_template = await get_ciconfig_file("git-push-template.yml")
+    task = jsone.render(
+        task_template,
+        {
+            "level": branch.level,
+            "trust_domain": project.trust_domain,
+            "hookGroupId": hookGroupId,
+            "hookId": hookId,
+            "project_repo": project.repo,
+            "project_role_prefix": project.role_prefix,
+            "alias": project.alias,
+        },
+    )
+
+    return Hook(
+        hookGroupId=hookGroupId,
+        hookId=hookId,
+        name=f"{hookGroupId}/{hookId}",
+        description=textwrap.dedent(
+            """\
+            On-push task for branch `{}` of repository {}.
+
+            This hook is triggered manually by in-repo tooling and creates a decision task.
+            """
+        ).format(branch.name, project.repo),
+        owner="release+tc-hooks@mozilla.com",
+        emailOnError=False,
+        schedule=[],
+        bindings=(),
+        task=task,
+        triggerSchema={
+            "type": "object",
+            "required": ["base_sha", "owner", "ref", "sha"],
+            "properties": {
+                "base_ref": {
+                    "type": ["string", "null"],
+                    "description": "The base ref for the push, if any.",
+                    "default": None,
+                },
+                "base_sha": {
+                    "type": "string",
+                    "pattern": "^[0-9a-f]{40}$",
+                    "description": "The commit SHA before the push.",
+                },
+                "owner": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "The email address of the user who pushed.",
+                    "default": "nobody@mozilla.com",
+                },
+                "ref": {
+                    "type": "string",
+                    "description": "The git ref that was pushed (e.g. refs/heads/main).",
+                },
+                "sha": {
+                    "type": "string",
+                    "pattern": "^[0-9a-f]{40}$",
+                    "description": "The commit SHA after the push.",
+                },
+            },
+            "additionalProperties": False,
+        },
+    )
+
+
+async def update_resources(resources):
+    """
+    Manage the hooks and roles for git-push resources.
+    """
+    projects = await Project.fetch_all()
+    projects = [p for p in projects if p.feature("git-push")]
+
+    resources.manage("Hook=git-push/.*")
+    resources.manage("Role=hook-id:git-push/.*")
+
+    for project in projects:
+        for branch in project.branches:
+            hook = await make_hook(project, branch)
+            resources.add(hook)
+
+            role = Role(
+                roleId=f"hook-id:{hook.hookGroupId}/{hook.hookId}",
+                description=f"Scopes associated with git pushes to branch `{branch.name}` of project `{project.alias}`",
+                scopes=[
+                    f"assume:repo:{hook.hookId}",
+                    f"queue:route:index.git-push.v1.{project.alias}.*",
+                    "queue:create-task:highest:infra/build-decision",
+                ],
+            )
+            resources.add(role)

--- a/tests/ciadmin/test_generate_git_pushes.py
+++ b/tests/ciadmin/test_generate_git_pushes.py
@@ -1,0 +1,142 @@
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+from tcadmin.appconfig import AppConfig
+from tcadmin.resources import Resources
+
+from ciadmin.generate import git_pushes
+from ciadmin.generate.ciconfig.projects import Project
+
+SIMPLE_TEMPLATE = {
+    "schedulerId": "${trust_domain}-level-${level}",
+    "scopes": ["assume:${project_role_prefix}:branch:*"],
+}
+
+GIT_PROJECT = Project(
+    alias="myproject",
+    branches=[
+        {"name": "main", "level": 3},
+        {"name": "dev", "level": 1},
+    ],
+    repo="https://github.com/mozilla/myproject",
+    repo_type="git",
+    trust_domain="foo",
+    features={"git-push": {"enabled": True}},
+)
+
+PROJECTS_YML = {
+    "myproject": {
+        "repo": "https://github.com/mozilla/myproject",
+        "repo_type": "git",
+        "trust_domain": "foo",
+        "branches": [{"name": "main", "level": 3}],
+        "features": {"git-push": {"enabled": True}},
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def appconfig():
+    with AppConfig._as_current(AppConfig()):
+        yield
+
+
+@pytest.mark.asyncio
+async def test_make_hook(mock_ciconfig_file):
+    mock_ciconfig_file("git-push-template.yml", SIMPLE_TEMPLATE)
+    hook = await git_pushes.make_hook(GIT_PROJECT, GIT_PROJECT.branches[0])
+
+    assert hook.hookGroupId == "git-push"
+    assert hook.hookId == "github.com/mozilla/myproject:branch:main"
+    assert "assume:repo:github.com/mozilla/myproject:branch:*" in hook.task["scopes"]
+
+    schema = hook.triggerSchema
+    assert schema["type"] == "object"
+    assert set(schema["required"]) == {
+        "sha",
+        "base_sha",
+        "ref",
+        "owner",
+    }
+    assert set(schema["properties"]) == {
+        "sha",
+        "base_sha",
+        "ref",
+        "owner",
+        "base_ref",
+    }
+    assert schema["properties"]["sha"]["pattern"] == "^[0-9a-f]{40}$"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "branch_idx,expected", [(0, "foo-level-3"), (1, "foo-level-1")]
+)
+async def test_make_hook_scheduler_id(mock_ciconfig_file, branch_idx, expected):
+    mock_ciconfig_file("git-push-template.yml", SIMPLE_TEMPLATE)
+    hook = await git_pushes.make_hook(GIT_PROJECT, GIT_PROJECT.branches[branch_idx])
+    assert hook.task["schedulerId"] == expected
+
+
+@pytest.mark.asyncio
+async def test_update_resources_filters_by_feature(mock_ciconfig_file):
+    mock_ciconfig_file("git-push-template.yml", SIMPLE_TEMPLATE)
+    mock_ciconfig_file(
+        "projects.yml",
+        {
+            "with-feature": {
+                **PROJECTS_YML["myproject"],
+                "repo": "https://github.com/mozilla/with-feature",
+            },
+            "without-feature": {
+                **PROJECTS_YML["myproject"],
+                "repo": "https://github.com/mozilla/without-feature",
+                "features": {},
+            },
+        },
+    )
+    r = Resources()
+    r.manage("Hook=git-push/.*")
+    r.manage("Role=hook-id:git-push/.*")
+    await git_pushes.update_resources(r)
+
+    hook_ids = {res.hookId for res in r if hasattr(res, "hookId")}
+    assert "github.com/mozilla/with-feature:branch:main" in hook_ids
+    assert "github.com/mozilla/without-feature:branch:main" not in hook_ids
+
+
+@pytest.mark.asyncio
+async def test_update_resources_one_hook_and_role_per_branch(mock_ciconfig_file):
+    branches = [{"name": "dev", "level": 1}, {"name": "main", "level": 3}]
+    mock_ciconfig_file("git-push-template.yml", SIMPLE_TEMPLATE)
+    mock_ciconfig_file(
+        "projects.yml",
+        {
+            "myproject": {
+                **PROJECTS_YML["myproject"],
+                "branches": branches,
+            }
+        },
+    )
+    resources = Resources()
+    resources.manage("Hook=git-push/.*")
+    resources.manage("Role=hook-id:git-push/.*")
+    await git_pushes.update_resources(resources)
+
+    hooks = [r for r in resources if hasattr(r, "hookId")]
+    roles = [r for r in resources if hasattr(r, "roleId")]
+    assert len(hooks) == 2
+    assert len(roles) == 2
+
+    for i, branch in enumerate(branches):
+        assert (
+            roles[i].roleId
+            == f"hook-id:git-push/github.com/mozilla/myproject:branch:{branch['name']}"
+        )
+        assert set(roles[i].scopes) == {
+            f"assume:repo:github.com/mozilla/myproject:branch:{branch['name']}",
+            "queue:route:index.git-push.v1.myproject.*",
+            "queue:create-task:highest:infra/build-decision",
+        }


### PR DESCRIPTION
There are cases where we want to run tasks where Taskcluster Github will not receive events:

1. When pushing a Git notes ref (because Github itself doesn't emit any webhook)
2. When pushing to a user fork of a project (because Taskcluster Github is not installed there)

Both these use cases are needed to help support "Github try pushes". The former because that's how we're going to transfer the try metadata the Decision task needs to know which tasks to schedule. The latter because pushing to forks is how most people work on Github, and it will be a lot nicer for them if they can just continue doing that without needing to push to a dedicated try repo for testing independently of their PRs.

This PR adds a new `build-decision git-push` subcommand, the ability to generate `git-push` hooks that call it, and a `replay-git-push` helper in fxci.