### PR TITLE
Switch ARM64 worker pools to Dpds_v5 VMs with ARM template deployment

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -3294,10 +3294,10 @@ pools:
       spot: true
       armDeployment:
         by-level:
+          1:
+            templateSpecId: /subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template/versions/1.0
           3:
             templateSpecId: /subscriptions/a30e97ab-734a-4f3b-a0e4-c51c0bff0701/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template/versions/1.0
-          default:
-            templateSpecId: /subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template/versions/1.0
       vmSizes:
         - vmSize: Standard_D16pds_v5
           launchConfig:
@@ -3394,10 +3394,10 @@ pools:
       spot: true
       armDeployment:
         by-level:
+          1:
+            templateSpecId: /subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template/versions/1.0
           3:
             templateSpecId: /subscriptions/a30e97ab-734a-4f3b-a0e4-c51c0bff0701/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template/versions/1.0
-          default:
-            templateSpecId: /subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template/versions/1.0
       vmSizes:
         - vmSize: Standard_D16pds_v5
           launchConfig:

--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -3283,17 +3283,23 @@ pools:
           config:
             workerType: win11-a64-24h2-builder-{suffix}
             provisionerId: '{pool-group}'
-            cachesDir: C:\caches
-            downloadsDir: C:\downloads
-            tasksDir: C:\
+            cachesDir: D:\caches
+            downloadsDir: D:\downloads
+            tasksDir: D:\
       tags:
         sourceScript: provisioners/windows/azure/azure-bootstrap.ps1
         sourceBranch: windows
         sourceRepository: ronin_puppet
         sourceOrganisation: mozilla-platform-ops
       spot: true
+      armDeployment:
+        by-level:
+          3:
+            templateSpecId: /subscriptions/a30e97ab-734a-4f3b-a0e4-c51c0bff0701/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template/versions/1.0
+          default:
+            templateSpecId: /subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template/versions/1.0
       vmSizes:
-        - vmSize: Standard_D16ps_v5
+        - vmSize: Standard_D16pds_v5
           launchConfig:
             osProfile:
               windowsConfiguration:
@@ -3302,11 +3308,12 @@ pools:
             storageProfile:
               osDisk:
                 osType: Windows
-                managedDisk:
-                  storageAccountType: Premium_LRS
+                caching: ReadOnly
                 createOption: FromImage
+                diffDiskSettings:
+                  option: Local
             hardwareProfile:
-              vmSize: Standard_D16ps_v5
+              vmSize: Standard_D16pds_v5
             diagnosticsProfile:
               bootDiagnostics:
                 enabled: false
@@ -3314,7 +3321,7 @@ pools:
         capacityPerInstance: 1
         initialWeight:
           by-vmSize:
-            Standard_D16ps_v5:
+            Standard_D16pds_v5:
               by-location:
                 central-india: 1
                 east-us-2: 0.9
@@ -3376,17 +3383,23 @@ pools:
           config:
             workerType: win11-a64-25h2-builder-{suffix}
             provisionerId: '{pool-group}'
-            cachesDir: C:\caches
-            downloadsDir: C:\downloads
-            tasksDir: C:\
+            cachesDir: D:\caches
+            downloadsDir: D:\downloads
+            tasksDir: D:\
       tags:
         sourceScript: provisioners/windows/azure/azure-bootstrap.ps1
         sourceBranch: master
         sourceRepository: ronin_puppet
         sourceOrganisation: mozilla-platform-ops
       spot: true
+      armDeployment:
+        by-level:
+          3:
+            templateSpecId: /subscriptions/a30e97ab-734a-4f3b-a0e4-c51c0bff0701/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template/versions/1.0
+          default:
+            templateSpecId: /subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template/versions/1.0
       vmSizes:
-        - vmSize: Standard_D16ps_v5
+        - vmSize: Standard_D16pds_v5
           launchConfig:
             osProfile:
               windowsConfiguration:
@@ -3395,11 +3408,12 @@ pools:
             storageProfile:
               osDisk:
                 osType: Windows
-                managedDisk:
-                  storageAccountType: Premium_LRS
+                caching: ReadOnly
                 createOption: FromImage
+                diffDiskSettings:
+                  option: Local
             hardwareProfile:
-              vmSize: Standard_D16ps_v5
+              vmSize: Standard_D16pds_v5
             diagnosticsProfile:
               bootDiagnostics:
                 enabled: false
@@ -3407,7 +3421,7 @@ pools:
         capacityPerInstance: 1
         initialWeight:
           by-vmSize:
-            Standard_D16ps_v5:
+            Standard_D16pds_v5:
               by-location:
                 central-india: 1
                 east-us-2: 0.9
@@ -4059,17 +4073,19 @@ pools:
           config:
             workerType: 'win11-a64-25h2-{suffix}'
             provisionerId: '{pool-group}'
-            cachesDir: C:\caches
-            downloadsDir: C:\downloads
-            tasksDir: C:\
+            cachesDir: D:\caches
+            downloadsDir: D:\downloads
+            tasksDir: D:\
       tags:
         sourceScript: provisioners/windows/azure/azure-bootstrap.ps1
         sourceBranch: master
         sourceRepository: ronin_puppet
         sourceOrganisation: mozilla-platform-ops
       spot: true
+      armDeployment:
+        templateSpecId: /subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template/versions/1.0
       vmSizes:
-        - vmSize: Standard_D8ps_v5
+        - vmSize: Standard_D8pds_v5
           launchConfig:
             osProfile:
               windowsConfiguration:
@@ -4078,9 +4094,12 @@ pools:
             storageProfile:
               osDisk:
                 osType: Windows
+                caching: ReadOnly
                 createOption: FromImage
+                diffDiskSettings:
+                  option: Local
             hardwareProfile:
-              vmSize: Standard_D8ps_v5
+              vmSize: Standard_D8pds_v5
             diagnosticsProfile:
               bootDiagnostics:
                 enabled: false
@@ -4088,7 +4107,7 @@ pools:
         capacityPerInstance: 1
         initialWeight:
           by-vmSize:
-            Standard_D16ps_v5:
+            Standard_D8pds_v5:
               by-location:
                 central-india: 1
                 uk-south: 0.9
@@ -4137,17 +4156,19 @@ pools:
           config:
             workerType: 'win11-a64-24h2-{suffix}'
             provisionerId: '{pool-group}'
-            cachesDir: C:\caches
-            downloadsDir: C:\downloads
-            tasksDir: C:\
+            cachesDir: D:\caches
+            downloadsDir: D:\downloads
+            tasksDir: D:\
       tags:
         sourceScript: provisioners/windows/azure/azure-bootstrap.ps1
         sourceBranch: windows
         sourceRepository: ronin_puppet
         sourceOrganisation: mozilla-platform-ops
       spot: true
+      armDeployment:
+        templateSpecId: /subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template/versions/1.0
       vmSizes:
-        - vmSize: Standard_D8ps_v5
+        - vmSize: Standard_D8pds_v5
           launchConfig:
             osProfile:
               windowsConfiguration:
@@ -4156,9 +4177,12 @@ pools:
             storageProfile:
               osDisk:
                 osType: Windows
+                caching: ReadOnly
                 createOption: FromImage
+                diffDiskSettings:
+                  option: Local
             hardwareProfile:
-              vmSize: Standard_D8ps_v5
+              vmSize: Standard_D8pds_v5
             diagnosticsProfile:
               bootDiagnostics:
                 enabled: false
@@ -4166,7 +4190,7 @@ pools:
         capacityPerInstance: 1
         initialWeight:
           by-vmSize:
-            Standard_D16ps_v5:
+            Standard_D8pds_v5:
               by-location:
                 central-india: 1
                 uk-south: 0.9


### PR DESCRIPTION
## Summary

- Migrate all `win11-a64` (24h2/25h2) builder and tester pools from `Standard_D*ps_v5` to `Standard_D*pds_v5` VM sizes, which include a local temp disk (300/600 GiB) enabling ephemeral OS disk support
- Add `armDeployment` with the existing ARM template spec (trusted + untrusted subscriptions for builders, untrusted for testers), bringing ARM64 pools in line with x86 pools
- Move worker directories from `C:\` to `D:\` (temp disk) to match x86 pool conventions
- Fix tester pool `initialWeight` `by-vmSize` keys that referenced `Standard_D16ps_v5` instead of the actual `D8` size

The `Dps_v5` series lacks a local temp disk, which prevented use of the ARM template spec (requires ephemeral OS disk via `diffDiskSettings.option: Local`). The `Dpds_v5` series adds local storage while keeping the same ARM64 Ampere Altra CPU and memory. Spot pricing order across regions is unchanged, so existing `initialWeight` rankings remain valid.

RELOPS-2042

## Test plan

- [ ] Verify ARM64 alpha pools provision successfully with the new VM size and template spec
- [ ] Confirm D:\ drive is available and worker caches/downloads/tasks land there
- [ ] Check that ephemeral OS disk is active (no managed OS disk created)
- [ ] Validate builder pools work for both trusted (level 3) and untrusted (level 1) variants
- [ ] Monitor spot instance availability across all regions (central-india, east-us-2, north-central-us, central-us, uk-south)