### PR TITLE
fix: ensure git-push hooks use valid hookIds

### DIFF
--- a/src/ciadmin/generate/git_pushes.py
+++ b/src/ciadmin/generate/git_pushes.py
@@ -13,7 +13,7 @@ from .ciconfig.projects import Project
 
 async def make_hook(project: Project, branch) -> Hook:
     hookGroupId = "git-push"
-    hookId = f"{project.role_prefix.removeprefix('repo:')}:branch:{branch.name}"
+    hookId = f"{project.repo_path}/{branch.name.rstrip('*')}"
 
     task_template = await get_ciconfig_file("git-push-template.yml")
     task = jsone.render(
@@ -99,7 +99,7 @@ async def update_resources(resources):
                 roleId=f"hook-id:{hook.hookGroupId}/{hook.hookId}",
                 description=f"Scopes associated with git pushes to branch `{branch.name}` of project `{project.alias}`",
                 scopes=[
-                    f"assume:repo:{hook.hookId}",
+                    f"assume:{project.role_prefix}:branch:{branch.name}",
                     f"queue:route:index.git-push.v1.{project.alias}.*",
                     "queue:create-task:highest:infra/build-decision",
                 ],

--- a/tests/ciadmin/test_generate_git_pushes.py
+++ b/tests/ciadmin/test_generate_git_pushes.py
@@ -49,7 +49,7 @@ async def test_make_hook(mock_ciconfig_file):
     hook = await git_pushes.make_hook(GIT_PROJECT, GIT_PROJECT.branches[0])
 
     assert hook.hookGroupId == "git-push"
-    assert hook.hookId == "github.com/mozilla/myproject:branch:main"
+    assert hook.hookId == "mozilla/myproject/main"
     assert "assume:repo:github.com/mozilla/myproject:branch:*" in hook.task["scopes"]
 
     schema = hook.triggerSchema
@@ -103,8 +103,8 @@ async def test_update_resources_filters_by_feature(mock_ciconfig_file):
     await git_pushes.update_resources(r)
 
     hook_ids = {res.hookId for res in r if hasattr(res, "hookId")}
-    assert "github.com/mozilla/with-feature:branch:main" in hook_ids
-    assert "github.com/mozilla/without-feature:branch:main" not in hook_ids
+    assert "mozilla/with-feature/main" in hook_ids
+    assert "mozilla/without-feature/main" not in hook_ids
 
 
 @pytest.mark.asyncio
@@ -131,10 +131,7 @@ async def test_update_resources_one_hook_and_role_per_branch(mock_ciconfig_file)
     assert len(roles) == 2
 
     for i, branch in enumerate(branches):
-        assert (
-            roles[i].roleId
-            == f"hook-id:git-push/github.com/mozilla/myproject:branch:{branch['name']}"
-        )
+        assert roles[i].roleId == f"hook-id:git-push/mozilla/myproject/{branch['name']}"
         assert set(roles[i].scopes) == {
             f"assume:repo:github.com/mozilla/myproject:branch:{branch['name']}",
             "queue:route:index.git-push.v1.myproject.*",


### PR DESCRIPTION
Turns out that the old one contained invalid characters for a hookId and I didn't find out until we attempted to deploy.