### PR TITLE
fix: add 'as_slugid' to 'git-push' context

### DIFF
--- a/build-decision/src/build_decision/git_push.py
+++ b/build-decision/src/build_decision/git_push.py
@@ -6,6 +6,8 @@ import json
 import logging
 import os
 
+import slugid
+
 from .decision import render_tc_yml
 
 logger = logging.getLogger(__name__)
@@ -33,11 +35,19 @@ def build_decision(*, repository, dry_run):
 
     tc_yml = repository.get_file(".taskcluster.yml", revision=event["after"])
 
+    _slugids = {}
+
+    def as_slugid(name):
+        if name not in _slugids:
+            _slugids[name] = slugid.nice()
+        return _slugids[name]
+
     task = render_tc_yml(
         tc_yml,
         taskcluster_root_url=os.environ["TASKCLUSTER_ROOT_URL"],
         tasks_for="git-push",
         event=event,
+        as_slugid=as_slugid,
     )
 
     task.display()

--- a/build-decision/tests/test_git_push.py
+++ b/build-decision/tests/test_git_push.py
@@ -54,6 +54,11 @@ def test_build_decision(mocker, dry_run):
     render_kwargs = mock_render.call_args[1]
     assert render_kwargs["taskcluster_root_url"] == taskcluster_root_url
     assert render_kwargs["tasks_for"] == "git-push"
+    as_slugid = render_kwargs["as_slugid"]
+    assert callable(as_slugid)
+    # Same name returns the same slugid; different names return different slugids
+    assert as_slugid("foo") == as_slugid("foo")
+    assert as_slugid("foo") != as_slugid("bar")
     assert render_kwargs["event"] == {
         "ref": "refs/heads/main",
         "before": HOOK_PAYLOAD["base_sha"],


### PR DESCRIPTION
This is context that Taskcluster Github provides to support creating new slugids withint JSON-e. We should provide a similar feature in `build-decision` so we don't need to handle the two cases separately within .taskcluster.yml

Bug: 2030733