### PR TITLE
Bug 2025695 - xpi-manifest: update lando action scope to version_bump on staging

### DIFF
--- a/grants.d/xpi.yml
+++ b/grants.d/xpi.yml
@@ -106,7 +106,7 @@
         job: action:release-promotion
 
 - grant:
-    - project:releng:lando:action:extension_manifest_version_bump
+    - project:releng:lando:action:version_bump
     - project:releng:lando:repo:staging-firefox-main
   to:
     - project:


### PR DESCRIPTION
[Bug 2025695](https://bugzilla.mozilla.org/show_bug.cgi?id=2025695)

## Summary

Follow-up to [#912](https://github.com/mozilla-releng/fxci-config/pull/912): updates the lando action scope name from `extension_manifest_version_bump` to `version_bump` after the landoscript action was renamed.

## Merge order

1. mozilla-releng/fxci-config [#912](https://github.com/mozilla-releng/fxci-config/pull/912) — merged ✓
2. **This PR** — merged ✓
3. mozilla-services/cloudops-infra [#6835](https://github.com/mozilla-services/cloudops-infra/pull/6835) (dev) — merged ✓
4. mozilla-services/cloudops-infra [#6848](https://github.com/mozilla-services/cloudops-infra/pull/6848) (chart secret) — merged ✓
5. k8s-sops: dev worker secrets — done ✓
6. mozilla-releng/k8s-autoscale [#264](https://github.com/mozilla-releng/k8s-autoscale/pull/264) (dev) — merged ✓
7. mozilla-releng/scriptworker-scripts [#1413](https://github.com/mozilla-releng/scriptworker-scripts/pull/1413) — merged ✓
8. mozilla-services/cloudops-infra [#6838](https://github.com/mozilla-services/cloudops-infra/pull/6838) (prod) — merged ✓
9. k8s-sops: prod worker secrets — manual step
10. mozilla-releng/k8s-autoscale [#266](https://github.com/mozilla-releng/k8s-autoscale/pull/266) (prod) — merged ✓
11. mozilla-releng/fxci-config [#979](https://github.com/mozilla-releng/fxci-config/pull/979) — fix production lando action scope — merged ✓
12. mozilla-extensions/xpi-manifest [#271](https://github.com/mozilla-extensions/xpi-manifest/pull/271) — merged ✓

## Verification

All verifications were done locally.