### PR TITLE
Bug 2032529 - Grant gecko level-1/2/3 scopes for win11-64-25h2-privileged

### DIFF
--- a/grants.d/grants.yml
+++ b/grants.d/grants.yml
@@ -277,6 +277,8 @@
     - generic-worker:run-as-administrator:gecko-t/win11-64-24h2-privileged-alpha
     - generic-worker:run-as-administrator:gecko-t/win11-64-24h2-privileged
     - generic-worker:run-as-administrator:gecko-t/win11-64-25h2-alpha
+    - generic-worker:run-as-administrator:gecko-t/win11-64-25h2-privileged-alpha
+    - generic-worker:run-as-administrator:gecko-t/win11-64-25h2-privileged
     - generic-worker:run-as-administrator:gecko-t/win11-64-2009
     - generic-worker:run-as-administrator:gecko-t/win11-64-24h2
     - generic-worker:run-as-administrator:gecko-t/win11-64-24h2-amd


### PR DESCRIPTION
Grants gecko level-1/2/3 the `generic-worker:run-as-administrator` scope for `gecko-t/win11-64-25h2-privileged` and `gecko-t/win11-64-25h2-privileged-alpha`.

Required by bug [2032529](https://bugzilla.mozilla.org/show_bug.cgi?id=2032529) / Phab [D294714](https://phabricator.services.mozilla.com/D294714), which routes `talos-xperf` at the 25H2 privileged pool. The try push currently fails with:

```
Missing scope: generic-worker:run-as-administrator:gecko-t/win11-64-25h2-privileged
```

The pools and `os-group:...Administrators` grants landed in #840. This adds the remaining `run-as-administrator` grants, mirroring #853 for 24H2.