### PR TITLE
Add opt-in per-region resource group for Azure ARM deployments

### DIFF
--- a/src/ciadmin/generate/worker_pools.py
+++ b/src/ciadmin/generate/worker_pools.py
@@ -182,8 +182,6 @@ def _build_arm_template_launch_config(
     }
 
     sanitized_pool = _sanitize_pool_id_for_rg(pool_id)
-    # Per-region-per-pool deployment RG so Azure's 800-deployments-per-RG
-    # quota is bounded by single-region arrival rate, not pool-wide.
     arm_resource_group = f"rg-tc-{sanitized_pool}-{loc}"
     # Azure RG names max 90 chars
     arm_resource_group = arm_resource_group[:90]

--- a/src/ciadmin/generate/worker_pools.py
+++ b/src/ciadmin/generate/worker_pools.py
@@ -182,7 +182,9 @@ def _build_arm_template_launch_config(
     }
 
     sanitized_pool = _sanitize_pool_id_for_rg(pool_id)
-    arm_resource_group = f"rg-tc-{sanitized_pool}"
+    # Per-region-per-pool deployment RG so Azure's 800-deployments-per-RG
+    # quota is bounded by single-region arrival rate, not pool-wide.
+    arm_resource_group = f"rg-tc-{sanitized_pool}-{loc}"
     # Azure RG names max 90 chars
     arm_resource_group = arm_resource_group[:90]
 

--- a/src/ciadmin/generate/worker_pools.py
+++ b/src/ciadmin/generate/worker_pools.py
@@ -120,15 +120,20 @@ def _sanitize_pool_id_for_rg(pool_id):
     return re.sub(r"[^a-zA-Z0-9\-_.]", "-", pool_id)
 
 
-def _arm_deployment_resource_group(pool_id, loc):
-    """Build the Azure RG name for a pool's deployments in a single region.
+def _arm_deployment_resource_group(pool_id, loc, per_region=False):
+    """Build the Azure RG name for a pool's deployments.
 
-    Truncates the pool segment only — `loc` always survives intact so the
-    per-region split holds even for pathologically long pool IDs.
+    When per_region is False (default), returns one RG per pool
+    (`rg-tc-<pool>`) — the layout from #922. When True, splits per region
+    (`rg-tc-<pool>-<loc>`) so a pool can't fill its RG to Azure's
+    800-deployments-per-RG cap during a burst. In the per-region case the
+    pool segment is truncated as needed; `loc` always survives intact.
     """
     sanitized_pool = _sanitize_pool_id_for_rg(pool_id)
-    max_pool_len = 90 - len("rg-tc-") - 1 - len(loc)
-    return f"rg-tc-{sanitized_pool[:max_pool_len]}-{loc}"
+    if per_region:
+        max_pool_len = 90 - len("rg-tc-") - 1 - len(loc)
+        return f"rg-tc-{sanitized_pool[:max_pool_len]}-{loc}"
+    return f"rg-tc-{sanitized_pool}"[:90]
 
 
 def _build_arm_template_launch_config(
@@ -192,7 +197,10 @@ def _build_arm_template_launch_config(
         "parameters": parameters,
     }
 
-    arm_resource_group = _arm_deployment_resource_group(pool_id, loc)
+    per_region_rg = pool_cfg.get("armDeploymentResourceGroupPerRegion", False)
+    arm_resource_group = _arm_deployment_resource_group(
+        pool_id, loc, per_region=per_region_rg
+    )
 
     launch_config = {
         "location": loc,

--- a/src/ciadmin/generate/worker_pools.py
+++ b/src/ciadmin/generate/worker_pools.py
@@ -120,6 +120,17 @@ def _sanitize_pool_id_for_rg(pool_id):
     return re.sub(r"[^a-zA-Z0-9\-_.]", "-", pool_id)
 
 
+def _arm_deployment_resource_group(pool_id, loc):
+    """Build the Azure RG name for a pool's deployments in a single region.
+
+    Truncates the pool segment only — `loc` always survives intact so the
+    per-region split holds even for pathologically long pool IDs.
+    """
+    sanitized_pool = _sanitize_pool_id_for_rg(pool_id)
+    max_pool_len = 90 - len("rg-tc-") - 1 - len(loc)
+    return f"rg-tc-{sanitized_pool[:max_pool_len]}-{loc}"
+
+
 def _build_arm_template_launch_config(
     *,
     pool_id,
@@ -181,10 +192,7 @@ def _build_arm_template_launch_config(
         "parameters": parameters,
     }
 
-    sanitized_pool = _sanitize_pool_id_for_rg(pool_id)
-    arm_resource_group = f"rg-tc-{sanitized_pool}-{loc}"
-    # Azure RG names max 90 chars
-    arm_resource_group = arm_resource_group[:90]
+    arm_resource_group = _arm_deployment_resource_group(pool_id, loc)
 
     launch_config = {
         "location": loc,

--- a/tests/ciadmin/test_generate_worker_pools.py
+++ b/tests/ciadmin/test_generate_worker_pools.py
@@ -262,7 +262,10 @@ def assert_azure_arm(pool):
         "vmSize": {"value": "Standard_F8s_v2"},
     }
 
-    assert launch_config["armDeploymentResourceGroup"] == "rg-tc-provId-my-worker-pool"
+    assert (
+        launch_config["armDeploymentResourceGroup"]
+        == "rg-tc-provId-my-worker-pool-useast1"
+    )
 
     assert "hardwareProfile" not in launch_config
     assert "storageProfile" not in launch_config

--- a/tests/ciadmin/test_generate_worker_pools.py
+++ b/tests/ciadmin/test_generate_worker_pools.py
@@ -12,6 +12,7 @@ from ciadmin.generate.ciconfig.environment import Environment
 from ciadmin.generate.ciconfig.worker_images import WorkerImage, WorkerImages
 from ciadmin.generate.ciconfig.worker_pools import WorkerPool
 from ciadmin.generate.worker_pools import (
+    _arm_deployment_resource_group,
     is_invalid_gcp_instance_type,
     make_worker_pool,
 )
@@ -519,3 +520,32 @@ def test_is_invalid_gcp_instance_type(invalid_instances, zone, machine_type, exp
     assert (
         is_invalid_gcp_instance_type(invalid_instances, zone, machine_type) == expected
     )
+
+
+@pytest.mark.parametrize(
+    "pool_id,loc,expected",
+    [
+        (
+            "provId/my-worker-pool",
+            "useast1",
+            "rg-tc-provId-my-worker-pool-useast1",
+        ),
+        (
+            "gecko-t/win11-64-25h2",
+            "australiacentral2",
+            "rg-tc-gecko-t-win11-64-25h2-australiacentral2",
+        ),
+        # Pool ID long enough that the pool segment must be truncated; loc
+        # must still survive intact so per-region split holds.
+        (
+            "provId/" + "x" * 200,
+            "australiacentral2",
+            "rg-tc-provId-" + "x" * 59 + "-australiacentral2",
+        ),
+    ],
+)
+def test_arm_deployment_resource_group(pool_id, loc, expected):
+    result = _arm_deployment_resource_group(pool_id, loc)
+    assert result == expected
+    assert len(result) <= 90
+    assert result.endswith(f"-{loc}")

--- a/tests/ciadmin/test_generate_worker_pools.py
+++ b/tests/ciadmin/test_generate_worker_pools.py
@@ -263,10 +263,7 @@ def assert_azure_arm(pool):
         "vmSize": {"value": "Standard_F8s_v2"},
     }
 
-    assert (
-        launch_config["armDeploymentResourceGroup"]
-        == "rg-tc-provId-my-worker-pool-useast1"
-    )
+    assert launch_config["armDeploymentResourceGroup"] == "rg-tc-provId-my-worker-pool"
 
     assert "hardwareProfile" not in launch_config
     assert "storageProfile" not in launch_config
@@ -523,29 +520,48 @@ def test_is_invalid_gcp_instance_type(invalid_instances, zone, machine_type, exp
 
 
 @pytest.mark.parametrize(
-    "pool_id,loc,expected",
+    "pool_id,loc,per_region,expected",
     [
+        # Default (per_region=False): one RG per pool, no location suffix.
         (
             "provId/my-worker-pool",
             "useast1",
+            False,
+            "rg-tc-provId-my-worker-pool",
+        ),
+        # Pool ID long enough to require 90-char truncation in default mode.
+        (
+            "provId/" + "x" * 200,
+            "useast1",
+            False,
+            ("rg-tc-provId-" + "x" * 200)[:90],
+        ),
+        # Opt-in (per_region=True): location appended.
+        (
+            "provId/my-worker-pool",
+            "useast1",
+            True,
             "rg-tc-provId-my-worker-pool-useast1",
         ),
         (
             "gecko-t/win11-64-25h2",
             "australiacentral2",
+            True,
             "rg-tc-gecko-t-win11-64-25h2-australiacentral2",
         ),
-        # Pool ID long enough that the pool segment must be truncated; loc
-        # must still survive intact so per-region split holds.
+        # Per-region with a pool ID long enough that the pool segment must
+        # be truncated; loc must still survive intact so the split holds.
         (
             "provId/" + "x" * 200,
             "australiacentral2",
+            True,
             "rg-tc-provId-" + "x" * 59 + "-australiacentral2",
         ),
     ],
 )
-def test_arm_deployment_resource_group(pool_id, loc, expected):
-    result = _arm_deployment_resource_group(pool_id, loc)
+def test_arm_deployment_resource_group(pool_id, loc, per_region, expected):
+    result = _arm_deployment_resource_group(pool_id, loc, per_region=per_region)
     assert result == expected
     assert len(result) <= 90
-    assert result.endswith(f"-{loc}")
+    if per_region:
+        assert result.endswith(f"-{loc}")


### PR DESCRIPTION
Continues the work from [taskcluster/taskcluster#8386](https://github.com/taskcluster/taskcluster/issues/8386). That issue reported the 800-deployments-per-RG cap being hit on the shared `rg-taskcluster-worker-manager-production` RG; #922 closed it by giving each pool its own deployment RG (`rg-tc-<pool>`). This PR adds an **opt-in** flag that splits per region (`rg-tc-<pool>-<loc>`), so a single pool's RG can't fill to the cap during a burst.

Default behavior is unchanged. The flag is enabled per pool in `worker-pools.yml`:

```yaml
config:
  armDeploymentResourceGroupPerRegion: true
```

## Why opt-in

Azure caps subscriptions at **980 resource groups, hard limit, not adjustable** ([source](https://learn.microsoft.com/azure/azure-resource-manager/management/azure-subscription-service-limits)). Across all the FXCI Azure pool families (gecko-t / gecko-1 / gecko-2 / comm-t / comm-1 / enterprise-t / enterprise-1 / nss-t / nss-1 / mozilla-1 / taskgraph-t) × their suffix matrices × ~14 regions each, a global rollout would add several hundred RGs at once. That's a lot of subscription budget to spend without first validating the change on the pool that actually needs it.

Opt-in lets us:
- enable on `gecko-t/win11-64-25h2` first (where the spike happened)
- watch live behavior for a week or two
- expand to other pools as evidence supports it

## Why this fix exists

`gecko-t/win11-64-25h2` got hit today: 1,373 worker requests in 60 minutes, deployment count up to 907 (past the 800 cap), Azure rejecting new deployments:

> Creating the deployment 'deploy-…' would exceed the quota of '800'. The current deployment count is '907'.

Worker-manager already deletes its own deployment records as the last step of the per-worker reap chain (`services/worker-manager/src/providers/azure/index.js:2137-2152`), and v99.2.0 made the chain faster. But during a spike, deployments arrive instantly while deletes wait on the reaper. The cap trips before the reaper catches up. Spreading deployments across per-region RGs bounds the per-RG arrival rate to a single region's share of pool weight — for a 14-region pool, that's roughly 14% of pool traffic in the busiest region.

## Diff

The RG-naming logic moved into `_arm_deployment_resource_group(pool_id, loc, per_region=False)`. When `per_region=False` (default), behavior matches #922 exactly. When True, the pool segment is truncated as needed; `loc` always survives intact so the split holds even for pathologically long pool IDs.

Parametrized regression test covers default mode (with 90-char truncation), opt-in mode (current shape and long-pool truncation). All 4 azure provider tests pass.

## For review

- No terraform changes — worker-manager auto-creates the RG on first use (per #922).
- No IAM changes — service principal has Contributor at subscription scope.
- No effect on existing pools until the flag is set on them. This PR doesn't enable it anywhere; flipping the flag on `gecko-t/win11-64-25h2` is a separate one-line change.
- Existing per-pool RGs go orphan when a pool is opted in. Their deployment history clears on its own; empty RGs can be deleted later.
- Region-removal cleanup for opted-in pools isn't covered here. Separate follow-up.

Independent of #946 — either can land first.