### PR TITLE
chore(azure): bump windows 1.3.1 and win11 25h2 1.0.2 image versions

### DIFF
--- a/worker-images.yml
+++ b/worker-images.yml
@@ -153,9 +153,9 @@ win11a6425h2builderalpha:
     name: win11_a64_25h2_builder_alpha
 trusted_win11_a64_25h2_builder:
   azure_trusted:
-    version: 1.0.0
+    version: 1.0.2
     resource_group: rg-packer-worker-images
-    deployment_id: alpha
+    deployment_id: "0e15b55"
     name: trusted_win11_a64_25h2_builder
 ronin_b1_windows11_a64_24h2_builder_alpha:
   azure2:

--- a/worker-images.yml
+++ b/worker-images.yml
@@ -115,22 +115,22 @@ ronin_b1_windows2022_64_2009_alpha:
     name: win2022_64_2009_alpha
 ronin_b1_windows2022_64_2009:
   azure2:
-    version: 1.3.0
+    version: 1.3.1
     resource_group: rg-packer-worker-images
-    deployment_id: "96de7f5"
+    deployment_id: "0e15b55"
     name: win2022_64_2009
 ronin_b3_windows2022_64_2009:
   azure_trusted:
-    version: 1.3.0
+    version: 1.3.1
     resource_group: rg-packer-worker-images
-    deployment_id: "96de7f5"
+    deployment_id: "0e15b55"
     name: trusted_win2022_64_2009
 # Windows 10
 ronin_t_windows10_64_2009_prod:
   azure2:
-    version: 1.3.0
+    version: 1.3.1
     resource_group: rg-packer-worker-images
-    deployment_id: "96de7f5"
+    deployment_id: "0e15b55"
     name: win10_64_2009
 ronin_t_windows10_64_2009_alpha:
   azure2:
@@ -141,9 +141,9 @@ ronin_t_windows10_64_2009_alpha:
 # Windows 11
 win11a6425h2builder:
   azure2:
-    version: 1.0.1
+    version: 1.0.2
     resource_group: rg-packer-worker-images
-    deployment_id: "82086a7"
+    deployment_id: "0e15b55"
     name: win11_a64_25h2_builder
 win11a6425h2builderalpha:
   azure2:
@@ -165,15 +165,15 @@ ronin_b1_windows11_a64_24h2_builder_alpha:
     name: win11_a64_24h2_builder_alpha
 ronin_b1_windows11_a64_24h2_builder:
   azure2:
-    version: 1.3.0
+    version: 1.3.1
     resource_group: rg-packer-worker-images
-    deployment_id: "96de7f5"
+    deployment_id: "0e15b55"
     name: win11_a64_24h2_builder
 ronin_b3_windows11_a64_24h2_builder:
   azure_trusted:
-    version: 1.3.0
+    version: 1.3.1
     resource_group: rg-packer-worker-images
-    deployment_id: "96de7f5"
+    deployment_id: "0e15b55"
     name: trusted_win11_a64_24h2_builder
 ronin_t_windows11_a64_24h2_tester_alpha:
   azure2:
@@ -183,15 +183,15 @@ ronin_t_windows11_a64_24h2_tester_alpha:
     name: win11_a64_24h2_tester_alpha
 ronin_t_windows11_a64_24h2_tester:
   azure2:
-    version: 1.3.0
+    version: 1.3.1
     resource_group: rg-packer-worker-images
-    deployment_id: "96de7f5"
+    deployment_id: "0e15b55"
     name: win11_a64_24h2_tester
 win11a6425h2tester:
   azure2:
-    version: 1.0.1
+    version: 1.0.2
     resource_group: rg-packer-worker-images
-    deployment_id: "82086a7"
+    deployment_id: "0e15b55"
     name: win11_a64_25h2_tester
 win11a6425h2testeralpha:
   azure2:
@@ -201,9 +201,9 @@ win11a6425h2testeralpha:
     name: win11_a64_25h2_tester_alpha
 ronin_t_windows11_64_24h2:
   azure2:
-    version: 1.3.0
+    version: 1.3.1
     resource_group: rg-packer-worker-images
-    deployment_id: "96de7f5"
+    deployment_id: "0e15b55"
     name: win11_64_24h2
 ronin_t_windows11_64_24h2_alpha:
   azure2:
@@ -213,9 +213,9 @@ ronin_t_windows11_64_24h2_alpha:
     name: win11_64_24h2_alpha
 win116425h2:
   azure2:
-    version: 1.0.1
+    version: 1.0.2
     resource_group: rg-packer-worker-images
-    deployment_id: "82086a7"
+    deployment_id: "0e15b55"
     name: win11_64_25h2
 win116425h2alpha:
   azure2:


### PR DESCRIPTION
## Summary
- Bumps the **Windows 24H2 family** to image version `1.3.1` and the **Win11 25H2 family** (including `trusted_win11_a64_25h2_builder`) to image version `1.0.2`. Both families now deploy from `ronin_puppet` `master` at commit [`0e15b55`](https://github.com/mozilla-platform-ops/ronin_puppet/commit/0e15b55) (`[RELOPS-2252] retry windows cloud worker bump`).
- **Taskcluster** updated to **`99.2.0`** across `GenericWorker`, `LiveLog`, `StartWorker`, and `Proxy` on every image.
- **Azure VM Agent** updated from `2.7.41491.1057` → `2.7.41491.1216` ([ronin_puppet #1165](https://github.com/mozilla-platform-ops/ronin_puppet/pull/1165)).
- **Windows patch level** — latest standard cumulative update on each OS:
  - Win11 24H2: `26100.8246` (KB5083769, 2026-04-14 — April 2026 Patch Tuesday)
  - Win11 25H2: `26200.8246` (KB5083769, 2026-04-14)
  - Win10 22H2: `19045.6456`
  - Windows Server 2022 21H2: `20348.5020`
- Built by [worker-images run #25064347208](https://github.com/mozilla-platform-ops/worker-images/actions/runs/25064347208) against `worker-images@df10437`.
- [RELOPS-2252](https://mozilla-hub.atlassian.net/browse/RELOPS-2252)

## ronin_puppet commits

### 24H2 range (`96de7f5...0e15b55`) — Windows-relevant
| Commit | Description |
|---|---|
| [`0e15b55`](https://github.com/mozilla-platform-ops/ronin_puppet/commit/0e15b55) | [RELOPS-2252] retry windows cloud worker bump (#1088) |
| [`e53e3fc`](https://github.com/mozilla-platform-ops/ronin_puppet/commit/e53e3fc) | Update Azure VM Agent from 2.7.41491.1057 to 2.7.41491.1216 (#1165) |
| [`22ae7fc`](https://github.com/mozilla-platform-ops/ronin_puppet/commit/22ae7fc) | [RELOPS-2314] Suppress OOBE/first-run windows on AVD SKU images (#1155) |
| [`1839a89`](https://github.com/mozilla-platform-ops/ronin_puppet/commit/1839a89) | [RELOPS-2289] Stabilize Windows Kitchen SYSTEM bootstrap output (#1149) |
| [`76624ed`](https://github.com/mozilla-platform-ops/ronin_puppet/commit/76624ed) | Enable spot instances for Windows kitchen platforms (#1142) |
| [`ab4adf8`](https://github.com/mozilla-platform-ops/ronin_puppet/commit/ab4adf8) | Add VC++ 2015-2022 Redistributable to Win11 25H2 tester image (#1138) |
| [`dbe0f55`](https://github.com/mozilla-platform-ops/ronin_puppet/commit/dbe0f55) | Generate ephemeral password for Windows kitchen jobs (#1128) |
| [`5841ac6`](https://github.com/mozilla-platform-ops/ronin_puppet/commit/5841ac6) | [RELOPS-2267] Add Windows serverspec coverage (#1102) |

[Full 24H2 compare](https://github.com/mozilla-platform-ops/ronin_puppet/compare/96de7f5...0e15b55)

### 25H2 range (`82086a7...0e15b55`) — Windows-relevant
| Commit | Description |
|---|---|
| [`0e15b55`](https://github.com/mozilla-platform-ops/ronin_puppet/commit/0e15b55) | [RELOPS-2252] retry windows cloud worker bump (#1088) |
| [`e53e3fc`](https://github.com/mozilla-platform-ops/ronin_puppet/commit/e53e3fc) | Update Azure VM Agent from 2.7.41491.1057 to 2.7.41491.1216 (#1165) |
| [`22ae7fc`](https://github.com/mozilla-platform-ops/ronin_puppet/commit/22ae7fc) | [RELOPS-2314] Suppress OOBE/first-run windows on AVD SKU images (#1155) |
| [`1839a89`](https://github.com/mozilla-platform-ops/ronin_puppet/commit/1839a89) | [RELOPS-2289] Stabilize Windows Kitchen SYSTEM bootstrap output (#1149) |
| [`76624ed`](https://github.com/mozilla-platform-ops/ronin_puppet/commit/76624ed) | Enable spot instances for Windows kitchen platforms (#1142) |

[Full 25H2 compare](https://github.com/mozilla-platform-ops/ronin_puppet/compare/82086a7...0e15b55)