### PR TITLE
Revert "chore(azure): bump windows 1.3.1 and win11 25h2 1.0.2 image versions (#955)"

### DIFF
--- a/worker-images.yml
+++ b/worker-images.yml
@@ -115,22 +115,22 @@ ronin_b1_windows2022_64_2009_alpha:
     name: win2022_64_2009_alpha
 ronin_b1_windows2022_64_2009:
   azure2:
-    version: 1.3.1
+    version: 1.3.0
     resource_group: rg-packer-worker-images
-    deployment_id: "0e15b55"
+    deployment_id: "96de7f5"
     name: win2022_64_2009
 ronin_b3_windows2022_64_2009:
   azure_trusted:
-    version: 1.3.1
+    version: 1.3.0
     resource_group: rg-packer-worker-images
-    deployment_id: "0e15b55"
+    deployment_id: "96de7f5"
     name: trusted_win2022_64_2009
 # Windows 10
 ronin_t_windows10_64_2009_prod:
   azure2:
-    version: 1.3.1
+    version: 1.3.0
     resource_group: rg-packer-worker-images
-    deployment_id: "0e15b55"
+    deployment_id: "96de7f5"
     name: win10_64_2009
 ronin_t_windows10_64_2009_alpha:
   azure2:
@@ -141,9 +141,9 @@ ronin_t_windows10_64_2009_alpha:
 # Windows 11
 win11a6425h2builder:
   azure2:
-    version: 1.0.2
+    version: 1.0.1
     resource_group: rg-packer-worker-images
-    deployment_id: "0e15b55"
+    deployment_id: "82086a7"
     name: win11_a64_25h2_builder
 win11a6425h2builderalpha:
   azure2:
@@ -153,9 +153,9 @@ win11a6425h2builderalpha:
     name: win11_a64_25h2_builder_alpha
 trusted_win11_a64_25h2_builder:
   azure_trusted:
-    version: 1.0.2
+    version: 1.0.0
     resource_group: rg-packer-worker-images
-    deployment_id: "0e15b55"
+    deployment_id: alpha
     name: trusted_win11_a64_25h2_builder
 ronin_b1_windows11_a64_24h2_builder_alpha:
   azure2:
@@ -165,15 +165,15 @@ ronin_b1_windows11_a64_24h2_builder_alpha:
     name: win11_a64_24h2_builder_alpha
 ronin_b1_windows11_a64_24h2_builder:
   azure2:
-    version: 1.3.1
+    version: 1.3.0
     resource_group: rg-packer-worker-images
-    deployment_id: "0e15b55"
+    deployment_id: "96de7f5"
     name: win11_a64_24h2_builder
 ronin_b3_windows11_a64_24h2_builder:
   azure_trusted:
-    version: 1.3.1
+    version: 1.3.0
     resource_group: rg-packer-worker-images
-    deployment_id: "0e15b55"
+    deployment_id: "96de7f5"
     name: trusted_win11_a64_24h2_builder
 ronin_t_windows11_a64_24h2_tester_alpha:
   azure2:
@@ -183,15 +183,15 @@ ronin_t_windows11_a64_24h2_tester_alpha:
     name: win11_a64_24h2_tester_alpha
 ronin_t_windows11_a64_24h2_tester:
   azure2:
-    version: 1.3.1
+    version: 1.3.0
     resource_group: rg-packer-worker-images
-    deployment_id: "0e15b55"
+    deployment_id: "96de7f5"
     name: win11_a64_24h2_tester
 win11a6425h2tester:
   azure2:
-    version: 1.0.2
+    version: 1.0.1
     resource_group: rg-packer-worker-images
-    deployment_id: "0e15b55"
+    deployment_id: "82086a7"
     name: win11_a64_25h2_tester
 win11a6425h2testeralpha:
   azure2:
@@ -201,9 +201,9 @@ win11a6425h2testeralpha:
     name: win11_a64_25h2_tester_alpha
 ronin_t_windows11_64_24h2:
   azure2:
-    version: 1.3.1
+    version: 1.3.0
     resource_group: rg-packer-worker-images
-    deployment_id: "0e15b55"
+    deployment_id: "96de7f5"
     name: win11_64_24h2
 ronin_t_windows11_64_24h2_alpha:
   azure2:
@@ -213,9 +213,9 @@ ronin_t_windows11_64_24h2_alpha:
     name: win11_64_24h2_alpha
 win116425h2:
   azure2:
-    version: 1.0.2
+    version: 1.0.1
     resource_group: rg-packer-worker-images
-    deployment_id: "0e15b55"
+    deployment_id: "82086a7"
     name: win11_64_25h2
 win116425h2alpha:
   azure2:


### PR DESCRIPTION
This reverts commit 909ca30e02f2240c5e7cf2360e7e8633eadfcce1.