### PR TITLE
revert gecko-t/win11-64-24h2 and 25h2 maxCapacity back to 1200

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -3660,7 +3660,7 @@ pools:
               default: 50
           gecko-t:
             by-suffix:
-              '': 2000
+              '': 1200
               alpha: 500
               gpu: 600
               default: 100
@@ -3894,7 +3894,7 @@ pools:
               default: 50
           gecko-t:
             by-suffix:
-              '': 2000
+              '': 1200
               alpha: 500
               gpu: 600
               default: 100


### PR DESCRIPTION
## Summary

- Reverts #916, restoring `gecko-t/win11-64-24h2` and `gecko-t/win11-64-25h2` base pool maxCapacity from 2000 back to 1200
- The increased workload that prompted the bump has subsided

## Test plan

- [ ] Verify pool configs apply correctly after merge