### PR TITLE
Move alpha worker pools out of uk-south

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -3150,8 +3150,8 @@ pools:
       worker-purpose: gecko-t
       locations:
         by-suffix:
-          alpha: [uk-south]
-          source-alpha: [uk-south, west-us-3, east-us, east-us-2, west-us, west-us-2, north-central-us, central-us]
+          alpha: [west-us-3, east-us, east-us-2, west-us-2, west-us]
+          source-alpha: [west-us-3, east-us, east-us-2, west-us, west-us-2, north-central-us, central-us]
           (webgpu|gpu)(-alpha)?: [west-us-3, east-us, east-us-2, west-us, west-us-2]
           default: [canada-central, central-india, east-us, east-us-2, west-us, west-us-2, west-us-3, north-central-us, central-us, north-europe, south-india]
       maxCapacity:
@@ -3479,7 +3479,7 @@ pools:
               default: [canada-central, east-us, east-us-2, west-us, west-us-2, west-us-3, north-central-us, central-us, north-europe, south-india]
           default:
             by-suffix:
-              (source-)?alpha: [uk-south]
+              (source-)?alpha: [west-us-3, east-us, east-us-2, west-us-2, west-us]
               webgpu(-alpha)?: [west-us-3, east-us, east-us-2, west-us, west-us-2]
               gpu(-alpha)?: [east-us, east-us-2, west-us, west-us-2]
               (ssd|source): [east-us, east-us-2, west-us, west-us-2, north-central-us, central-us]
@@ -3646,7 +3646,7 @@ pools:
               default: [canada-central, east-us, east-us-2, west-us, west-us-2, west-us-3, north-central-us, central-us, north-europe, south-india]
           default:
             by-suffix:
-              (source-)?alpha: [uk-south]
+              (source-)?alpha: [west-us-3, east-us, east-us-2, west-us-2, west-us]
               webgpu(-alpha)?: [west-us-3, east-us, east-us-2, west-us, west-us-2]
               gpu(-alpha)?: [east-us, east-us-2, west-us, west-us-2]
               (ssd|source): [west-us-3, east-us, east-us-2, west-us, west-us-2, north-central-us, central-us]
@@ -3881,7 +3881,7 @@ pools:
               default: [canada-central, east-us, east-us-2, west-us, west-us-2, west-us-3, north-central-us, central-us, north-europe, south-india]
           default:
             by-suffix:
-              (source-)?alpha: [uk-south]
+              (source-)?alpha: [west-us-3, east-us, east-us-2, west-us-2, west-us]
               (webgpu|gpu)(-alpha)?: [west-us-3, east-us, east-us-2, west-us, west-us-2]
               (ssd|source): [west-us-3, east-us, east-us-2, west-us, west-us-2, north-central-us, central-us]
               ssd-gpu: [north-europe, east-us, east-us-2]


### PR DESCRIPTION
## Summary

uk-south rotated its IMDS certificate and our `-alpha` workers no longer provision successfully there. See [taskcluster/taskcluster#8569](https://github.com/taskcluster/taskcluster/issues/8569) for the upstream tracking issue.

This swaps every `-alpha` / `source-alpha` location list to a five-region US set that supports the same SKUs (`Standard_F8s_v2`, `Standard_E8ads_v5`, `Standard_NV12ads_A10_v5`) and is already proven by the existing `gpu`/`source` pools.

**New region list:** `[west-us-3, east-us, east-us-2, west-us-2, west-us]`

`west-us-3` carries the highest configured `initialWeight` (1.0) for both `Standard_F8s_v2` and `Standard_NV12ads_A10_v5`, so it stays a strong default; the four US regions provide redundancy.

Affected pool families:
- `gecko-t/win10-64-2009-{alpha,source-alpha}` (lines 3153-3154)
- `gecko-t/win11-64-2009-{alpha,source-alpha}` (line 3482)
- `gecko-t/win11-64-24h2-{alpha,source-alpha}` (line 3649)
- `gecko-t/win11-64-25h2-{alpha,source-alpha}` (line 3884)

The `gpu-alpha` / `webgpu-alpha` pools were already on US regions via separate by-suffix entries and are unaffected.

Non-alpha pools still pinned to uk-south (e.g. `win11-64-25h2-amd`, `b-win-aarch64`) are out of scope.

## Test plan

- [ ] `tc-admin diff` shows only the location-list changes for the four alpha pool families
- [ ] CI `tc-admin check` passes
- [ ] After merge: confirm new alpha workers spawn in the US regions and stop provisioning attempts in uk-south