### PR TITLE
feat(gcp): Update Ubuntu 24.04 images with copy-fail patch

### DIFF
--- a/worker-images.yml
+++ b/worker-images.yml
@@ -77,7 +77,7 @@ relsre-gw-fxci-gcp-2404-amd64-gui-alpha:
 ubuntu-2404-wayland:
   ## Bug 1902716
   ## 2404 ubuntu image with wayland
-  fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-2404-amd64-gui-googlecompute-2026-03-05
+  fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-2404-amd64-gui-googlecompute-2026-05-04
 
 relsre-gw-fxci-gcp-2404-amd64-alpha:
   ## alpha pool that relsre can use to rebuild and test 2404 ubuntu images
@@ -90,8 +90,8 @@ ubuntu-2404-headless-alpha:
 
 ubuntu-2404-headless:
   ## Headless Image for Ubuntu 24.04
-  fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-2404-amd64-headless-googlecompute-2026-03-05
-  fxci-level3-gcp: projects/fxci-production-level3-workers/global/images/gw-fxci-gcp-l3-2404-amd64-headless-googlecompute-2026-03-05
+  fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-2404-amd64-headless-googlecompute-2026-05-04
+  fxci-level3-gcp: projects/fxci-production-level3-workers/global/images/gw-fxci-gcp-l3-2404-amd64-headless-googlecompute-2026-05-04
 
 ubuntu-2404-headless-alpha-tc:
   ## alpha pool that tc can use to rebuild and test 2404 headless ubuntu images
@@ -103,8 +103,8 @@ ubuntu-2404-arm64-headless-alpha:
   fxci-level3-gcp: projects/fxci-production-level3-workers/global/images/gw-fxci-gcp-l3-2404-arm64-headless-googlecompute-alpha
 ubuntu-2404-arm64-headless:
   ## Headless Image for Ubuntu 24.04 arm64
-  fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-2404-arm64-headless-googlecompute-2026-03-05
-  fxci-level3-gcp: projects/fxci-production-level3-workers/global/images/gw-fxci-gcp-l3-2404-arm64-headless-googlecompute-2026-03-05
+  fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-2404-arm64-headless-googlecompute-2026-05-04
+  fxci-level3-gcp: projects/fxci-production-level3-workers/global/images/gw-fxci-gcp-l3-2404-arm64-headless-googlecompute-2026-05-04
 
 # Windows Server 2022
 ronin_b1_windows2022_64_2009_alpha:


### PR DESCRIPTION
## Summary

- Updates the Ubuntu 24.04 GCP worker image references to the `2026-05-04` builds for `ubuntu-2404-wayland`, `ubuntu-2404-headless`, and `ubuntu-2404-arm64-headless`.
- Promotes the patched images produced from [mozilla-platform-ops/worker-images run 25333982727](https://github.com/mozilla-platform-ops/worker-images/actions/runs/25333982727) to address a Linux privilege-escalation vulnerability that allows untrusted code to obtain root.

## Related

- [RELOPS-2347](https://mozilla-hub.atlassian.net/browse/RELOPS-2347)