### PR TITLE
fix(taskcluster): mirror build-vocab fetches for translations

### DIFF
--- a/taskcluster/kinds/firefoxci-artifact/kind.yml
+++ b/taskcluster/kinds/firefoxci-artifact/kind.yml
@@ -70,5 +70,6 @@ tasks:
     # unmirrored, non-docker image task in addition to a mirrored task.
     mirror-public-fetches:
       - ^toolchain.*
+      - ^build-vocab.*
       - ^corpus-clean-parallel-bicleaner-ai.*
       - ^corpus-clean-.*


### PR DESCRIPTION
## Summary

- Mirrors public fetch artifacts for translations `build-vocab` tasks during staging integration tests.
- Fixes the issue-comment decision task failure where `translations-build-vocab-ru-en` ended up with `MOZ_FETCHES` split between staging and production Taskcluster.

## Jira

- [RELOPS-2352](https://mozilla-hub.atlassian.net/browse/RELOPS-2352)

## Related pull requests

- #968: the Ubuntu 24.04 image update PR where the `/ci` issue-comment decision task exposed this failure.
- #810: prior fix for the same mixed stage/production fetch failure mode in translations `corpus-clean` tasks.
- #442: changed translations integration tests to use `mirror-public-fetches` for selected public artifacts.
- #361: earlier translations fetch mirroring work for integration tests.

## Validation

- `uv run pytest taskcluster/test/test_transforms_firefoxci_artifact.py taskcluster/test/test_transforms_integration_test.py`
- Local staging integration scan against the current indexed Gecko/translations decision tasks: `mixed fetch cases: 0`
