### PR TITLE
fix: improve error message when mirrored tasks depend on stage and prod

### DIFF
--- a/taskcluster/fxci_config_taskgraph/transforms/integration_test.py
+++ b/taskcluster/fxci_config_taskgraph/transforms/integration_test.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import shlex
+from collections import defaultdict
 from textwrap import dedent
 from typing import Any
 
@@ -285,6 +286,7 @@ def make_integration_test_description(
     modified to work with staging.
     """
     assert "TASK_ID" in os.environ
+    task_name = f"{name_prefix}-{task_def['metadata']['name']}"
     task_def.update(
         {
             "schedulerId": "releng-level-1",
@@ -307,9 +309,9 @@ def make_integration_test_description(
         if key in task_def:
             task_def[key] = task_def[key].replace("3", "1")
 
-    task_def["metadata"]["name"] = f"{name_prefix}-{task_def['metadata']['name']}"
+    task_def["metadata"]["name"] = task_name
     taskdesc = {
-        "label": task_def["metadata"]["name"],
+        "label": task_name,
         "description": task_def["metadata"]["description"],
         "task": task_def,
         "dependencies": {
@@ -346,7 +348,7 @@ def make_integration_test_description(
         .get("MOZ_FETCHES", {})
         .get("task-reference", "{}")
     )
-    task_locations = set()
+    task_locations = defaultdict(set)
     for f in fetches:
         name = f["task"].strip("<>")
         # It would be preferable if we checked for full task labels rather
@@ -354,13 +356,13 @@ def make_integration_test_description(
         # depend on one another, and we don't try to create them in graph order,
         # there's no guarantee that this check would reliably.
         if name in artifact_tasks or name.startswith(f"{name_prefix}-"):
-            task_locations.add("stage")
+            task_locations["stage"].add(name)
         else:
-            task_locations.add("prod")
+            task_locations["prod"].add(name)
 
     if len(task_locations) == 2:
         raise Exception(
-            "Cannot run a task with fetches from stage and production clusters."
+            f"Cannot run a task with fetches from stage and production clusters. {task_name} depends on the following task/clusters: {task_locations}"
         )
 
     if "prod" in task_locations:


### PR DESCRIPTION
example:
```
Exception: Cannot run task with fetches from stage and production clusters. translations-build-vocab-ru-en depends on the following task/clusters: defaultdict(<class 'set'>, {'stage': {'translations-toolchain-marian', 'translations-corpus-merge-parallel-ru-en'}, 'prod': {'YtV46H_fTEeoeAP-BsYE7w', 'DBWfYHC5ShGSVHrJ6kGBnA', 'KNljjLQGQ26TvBTw2mbihQ', 'YzcouzkVRAWLLJtHGM6tfQ'}})
```

(It's unfortunate that we only get task ids for prod; but we don't have a handle on those tasks, so it's the best we can do without looking up the task names, which is not worthwhile for an error message IMO.)