### PR TITLE
fix: grant ability to seal pre-commit task groups

### DIFF
--- a/grants.d/grants.yml
+++ b/grants.d/grants.yml
@@ -1079,6 +1079,7 @@
 
 - grant:
     - hooks:trigger-hook:lint/pre-commit-*
+    - queue:seal-task-group:lint/*
   to:
     - project:
         feature: pre-commit


### PR DESCRIPTION
This is needed if you force push a PR that has a pre-commit hook still running. TC Github will attempt to seal the task group and fail without this scope.