### PR TITLE
fix(azure): drop eastus2 from win11-64-25h2 GPU pools (RELOPS-2354)

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -3882,7 +3882,7 @@ pools:
           default:
             by-suffix:
               (source-)?alpha: [west-us-3, east-us, east-us-2, west-us-2, west-us]
-              (webgpu|gpu)(-alpha)?: [west-us-3, east-us, east-us-2, west-us, west-us-2]
+              (webgpu|gpu)(-alpha)?: [west-us-3, east-us, west-us, west-us-2]
               (ssd|source): [west-us-3, east-us, east-us-2, west-us, west-us-2, north-central-us, central-us]
               ssd-gpu: [north-europe, east-us, east-us-2]
               default: [canada-central, central-india, east-us, east-us-2, west-us, west-us-2, west-us-3, north-central-us, central-us, north-europe, south-india]
@@ -3975,8 +3975,7 @@ pools:
               by-location:
                 west-us-3: 1
                 east-us: 1
-                west-us-2: 0.8
-                east-us-2: 0.8
+                west-us-2: 1
                 default: 0.5
             Standard_E8ads_v6:
               by-location:


### PR DESCRIPTION
## Summary

- Drop `east-us-2` from the `(webgpu|gpu)(-alpha)?` locations list on `win11-64-25h2-{suffix}`.
- Remove `east-us-2: 0.8` from the `Standard_NV12ads_A10_v5` weight block. Bump `west-us-2` from `0.8` to `1` to take the redirected load.

JIRA: [RELOPS-2354](https://mozilla-hub.atlassian.net/browse/RELOPS-2354)

## Background

The last 7 days surfaced 39 `VMStartTimedOut` events across all Windows worker pools, of which 30 (77%) were in eastus2. By pool, 28 of those eastus2 events landed on `gecko-t/win11-64-25h2-gpu` (16) and `gecko-t/win11-64-25h2-webgpu` (12). Events cluster in tight bursts (e.g. 6 webgpu timeouts in 12 seconds on 2026-05-01 22:17), which points to region-wide A10 fabric pressure rather than per-VM problems.

This is a different failure mode from the `OperationPreempted` spot-eviction case seen on the same pools earlier. Both happen in eastus2 because Mozilla's A10 demand is concentrated there and Azure's A10 capacity is tightest there. Azure's published Windows Spot cap for `Standard_NV12ads_A10_v5` matches: $0.2994/hr in eastus2 versus $0.2698/hr in westus3, eastus, and westus2.

## Why this approach

- westus3 is already in the locations list and already weighted at `1.0`.
- westus3 had zero `VMStartTimedOut` events over the same 7-day window.
- The `win11_64_25h2` v1.0.2 gallery image is already replicated to westus3, eastus, westus, and westus2.
- The change is reversible: if westus3, eastus, or westus2 capacity tightens later, the eastus2 entry can be added back.

## Pools affected

- `gecko-t/win11-64-25h2-gpu`
- `gecko-t/win11-64-25h2-gpu-alpha`
- `gecko-t/win11-64-25h2-webgpu`
- `gecko-t/win11-64-25h2-webgpu-alpha`

## Out of scope

- 24h2-gpu had 6 events but in westus2, not eastus2. Different problem, separate ticket if needed.
- 2009 pools have low signal.
- The `ssd-gpu` suffix locations only span 3 regions and have no failure data.

## Test plan

- [x] `pre-commit run --files worker-pools.yml`
- [x] `pytest tests/ciadmin/test_generate_worker_pools.py tests/ciadmin/test_generate_ciconfig_worker_pools.py` (24 passed)
- [ ] Monitor `VMStartTimedOut` rate on 25h2-gpu and 25h2-webgpu over the next 7 days post-deploy