### PR TITLE
fix: only create pre-commit task for push and pull-request events

### DIFF
--- a/hook-templates/project-releng/pre-commit.yml
+++ b/hook-templates/project-releng/pre-commit.yml
@@ -6,64 +6,72 @@ $let:
       headSha: {$eval: payload.event.pull_request.head.sha}
       headRef: {$eval: payload.event.pull_request.head.ref}
       repoName: {$eval: "join(split(payload.event.repository.full_name, '/'), '-')"}
+      isPullRequest: true
+      pullRequestAction: payload.event.action
     'payload.tasks_for == "github-push"':
       repoUrl: {$eval: payload.event.repository.html_url}
       headSha: {$eval: payload.event.after}
       headRef: {$eval: payload.event.ref}
       repoName: {$eval: "join(split(payload.event.repository.full_name, '/'), '-')"}
+      isPullRequest: false
+      pullRequestAction: 'UNDEFINED'
 in:
-  $let:
-    preCommitInstallSpec:
-      $if: "'context' in payload && 'pre-commit-version' in payload.context"
-      then: {$eval: "'pre-commit==' + payload.context['pre-commit-version']"}
-      else: pre-commit
-    shortHeadRef:
-      $switch:
-        'headRef[:10] == "refs/tags/"': '${headRef[10:]}'
-        'headRef[:11] == "refs/heads/"': '${headRef[11:]}'
-        $default: '${headRef}'
-  in:
-    created: {$fromNow: 0 seconds}
-    deadline: {$fromNow: 2 hours}
-    expires: {$fromNow: 1 month}
-    metadata:
-      name: pre-commit-{version}
-      description: Run pre-commit checks
-      owner: release+hooks@mozilla.com
-      source: ${repoUrl}
-    payload:
-      capabilities: {}
-      cache:
-        lint-pre-commit-uv-v1: /builds/worker/.cache/uv
-        lint-pre-commit-repos-v1: /builds/worker/.cache/pre-commit
-        lint-pre-commit-checkout-${repoName}-v1: /builds/worker/checkouts
-      env:
-        SRC_HEAD_REPOSITORY: ${repoUrl}
-        SRC_HEAD_REV: ${headSha}
-        SRC_HEAD_REF: ${headRef}
-        SRC_REPOSITORY_TYPE: git
-        UV_CACHE_DIR: /builds/worker/.cache/uv
-        PRE_COMMIT_HOME: /builds/worker/.cache/pre-commit
-        TASKCLUSTER_CACHES: /builds/worker/.cache/uv;/builds/worker/.cache/pre-commit;/builds/worker/checkouts
-        REPOSITORIES:
-          $json: {src: Source}
-      features:
-        taskclusterProxy: true
-      image: mozillareleases/taskgraph:run-task-v20.0.0@sha256:a905d5e14a97f0d313319b6bec4e5d670cf4505747e0cbaf360226046c1d4511
-      maxRunTime: 3600
-      command:
-        - run-task
-        - --src-checkout=/builds/worker/checkouts/src
-        - --task-cwd=/builds/worker/checkouts/src
-        - --
-        - bash
-        - -c
-        - uv tool install ${preCommitInstallSpec} && /builds/worker/.local/bin/pre-commit run --all-files
-    priority: lowest
-    provisionerId: mozilla-t
-    routes:
-      - checks
-    schedulerId: lint
-    scopes:
-      - assume:hook-id:lint/pre-commit-{version}
-    workerType: pre-commit
+  $if: >
+     (tasks_for == "github-push")
+     || (isPullRequest && pullRequestAction in ["opened", "reopened", "synchronize"])
+  then:
+    $let:
+      preCommitInstallSpec:
+        $if: "'context' in payload && 'pre-commit-version' in payload.context"
+        then: {$eval: "'pre-commit==' + payload.context['pre-commit-version']"}
+        else: pre-commit
+      shortHeadRef:
+        $switch:
+          'headRef[:10] == "refs/tags/"': '${headRef[10:]}'
+          'headRef[:11] == "refs/heads/"': '${headRef[11:]}'
+          $default: '${headRef}'
+    in:
+      created: {$fromNow: 0 seconds}
+      deadline: {$fromNow: 2 hours}
+      expires: {$fromNow: 1 month}
+      metadata:
+        name: pre-commit-{version}
+        description: Run pre-commit checks
+        owner: release+hooks@mozilla.com
+        source: ${repoUrl}
+      payload:
+        capabilities: {}
+        cache:
+          lint-pre-commit-uv-v1: /builds/worker/.cache/uv
+          lint-pre-commit-repos-v1: /builds/worker/.cache/pre-commit
+          lint-pre-commit-checkout-${repoName}-v1: /builds/worker/checkouts
+        env:
+          SRC_HEAD_REPOSITORY: ${repoUrl}
+          SRC_HEAD_REV: ${headSha}
+          SRC_HEAD_REF: ${headRef}
+          SRC_REPOSITORY_TYPE: git
+          UV_CACHE_DIR: /builds/worker/.cache/uv
+          PRE_COMMIT_HOME: /builds/worker/.cache/pre-commit
+          TASKCLUSTER_CACHES: /builds/worker/.cache/uv;/builds/worker/.cache/pre-commit;/builds/worker/checkouts
+          REPOSITORIES:
+            $json: {src: Source}
+        features:
+          taskclusterProxy: true
+        image: mozillareleases/taskgraph:run-task-v20.0.0@sha256:a905d5e14a97f0d313319b6bec4e5d670cf4505747e0cbaf360226046c1d4511
+        maxRunTime: 3600
+        command:
+          - run-task
+          - --src-checkout=/builds/worker/checkouts/src
+          - --task-cwd=/builds/worker/checkouts/src
+          - --
+          - bash
+          - -c
+          - uv tool install ${preCommitInstallSpec} && /builds/worker/.local/bin/pre-commit run --all-files
+      priority: lowest
+      provisionerId: mozilla-t
+      routes:
+        - checks
+      schedulerId: lint
+      scopes:
+        - assume:hook-id:lint/pre-commit-{version}
+      workerType: pre-commit


### PR DESCRIPTION
Guard against attempting to create tasks for events like check_run and issue_comment.