### PR TITLE
fix: explicitly add anonymous role to hook scopes

### DIFF
--- a/src/ciadmin/generate/hooks.py
+++ b/src/ciadmin/generate/hooks.py
@@ -55,6 +55,12 @@ def generate_hook_variants(hooks):
             for field in fields:
                 resolve_keyed_by(fields, field, hook_name, **attributes)
 
+            scopes = [s.format(**attributes) for s in hook.scopes]
+
+            # Explicitly add the anonymous role to avoid scope errors fetching
+            # public/github/customCheckRunText.md (which TC Github looks for).
+            scopes.append("assume:anonymous")
+
             yield attr.evolve(
                 hook,
                 hook_group_id=hook.hook_group_id.format(**attributes),
@@ -62,7 +68,7 @@ def generate_hook_variants(hooks):
                 name=hook.name.format(**attributes),
                 description=hook.description.format(**attributes),
                 template_file=fields["template_file"].format(**attributes),
-                scopes=[s.format(**attributes) for s in hook.scopes],
+                scopes=scopes,
                 attributes=attributes,
                 variants=[{}],
             )

--- a/tests/ciadmin/test_generate_hooks.py
+++ b/tests/ciadmin/test_generate_hooks.py
@@ -43,6 +43,7 @@ def test_substitution():
     assert result.scopes == [
         "queue:create-task:highest:my-pool",
         "secrets:get:runtime-production",
+        "assume:anonymous",
     ]
 
 


### PR DESCRIPTION
Taskcluster Github makes an authenticated request to fetch public/github/customCheckRunText.md. Even though this is a public artifact, the request hits a 401 because it's authenticated with a bewit url and so the anonymous role doesn't apply.

It's unclear whether this is a bug or not, but in the meantime, explicitly granting the anonymous role to the hook role should make it work.