### PR TITLE
chore: create temporary worker pool to test balrog mozcloud environment

### DIFF
--- a/clients.yml
+++ b/clients.yml
@@ -648,6 +648,11 @@ project/releng/scriptworker/v2/balrog/prod/firefoxci-gecko-3:
   scopes:
     - queue:claim-work:scriptworker-k8s/gecko-3-balrog
     - queue:worker-id:gecko-3-balrog/gecko-3-balrog-*
+project/releng/scriptworker/v2/balrog/prod/firefoxci-gecko-3-mozcloud:
+  description: ''
+  scopes:
+    - queue:claim-work:scriptworker-k8s/gecko-3-balrog-mozcloud
+    - queue:worker-id:gecko-3-balrog/gecko-3-balrog-mozcloud-*
 project/releng/scriptworker/v2/balrog/dev/firefoxci-xpi-1:
   description: ''
   scopes:


### PR DESCRIPTION
We need to be able to test balrogscript writes to the new MozCloud production environment. We can't do this with dev workers, because they don't have access to production environments. Instead, we'll create a special L3 pool that we'll use on Maple or another project branch to test writes; this will never be used by Nightly, Beta, etc., and will be deleted once testing is complete.