### PR TITLE
Bug 2025695 - projects: set staging-xpi-manifest default branch to main

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -1252,6 +1252,7 @@ xpi-manifest:
 staging-xpi-manifest:
   repo: https://github.com/mozilla-releng/staging-xpi-manifest
   repo_type: git
+  default_branch: main
   branches:
     - name: "*"
       level: 1


### PR DESCRIPTION
## Verification

Triggers staging ci-admin apply to pick up the new `.taskcluster.yml` hash from staging-xpi-manifest after [Bug 2025695](https://bugzilla.mozilla.org/show_bug.cgi?id=2025695) changes.