### PR TITLE
Bug 2025695 - xpi-manifest: fix production lando action scope to version_bump

### DIFF
--- a/grants.d/xpi.yml
+++ b/grants.d/xpi.yml
@@ -98,7 +98,7 @@
 
 # Bug 2025695: lando scopes for newtab XPI version bump
 - grant:
-    - project:releng:lando:action:extension_manifest_version_bump
+    - project:releng:lando:action:version_bump
     - project:releng:lando:repo:firefox-main
   to:
     - project:


### PR DESCRIPTION
Follow-up to https://github.com/mozilla-releng/fxci-config/pull/933, which fixed the staging grant but missed the production one.

References [Bug 2025695](https://bugzilla.mozilla.org/show_bug.cgi?id=2025695).

## Merge order

1. mozilla-releng/fxci-config [#912](https://github.com/mozilla-releng/fxci-config/pull/912) — merged ✓
2. mozilla-releng/fxci-config [#933](https://github.com/mozilla-releng/fxci-config/pull/933) — merged ✓ (scope name update)
3. mozilla-services/cloudops-infra [#6835](https://github.com/mozilla-services/cloudops-infra/pull/6835) (dev) — merged ✓
4. mozilla-services/cloudops-infra [#6848](https://github.com/mozilla-services/cloudops-infra/pull/6848) (chart secret) — merged ✓
5. k8s-sops: dev worker secrets — done ✓
6. mozilla-releng/k8s-autoscale [#264](https://github.com/mozilla-releng/k8s-autoscale/pull/264) (dev) — merged ✓
7. mozilla-releng/scriptworker-scripts [#1413](https://github.com/mozilla-releng/scriptworker-scripts/pull/1413) — merged ✓
8. mozilla-services/cloudops-infra [#6838](https://github.com/mozilla-services/cloudops-infra/pull/6838) (prod) — merged ✓
9. k8s-sops: prod worker secrets — manual step
10. mozilla-releng/k8s-autoscale [#266](https://github.com/mozilla-releng/k8s-autoscale/pull/266) (prod) — merged ✓
11. **This PR** — merged ✓
12. mozilla-extensions/xpi-manifest [#271](https://github.com/mozilla-extensions/xpi-manifest/pull/271) — merged ✓

## Verification

Merging this PR triggers a production ci-admin apply that also creates the new action hook matching the updated `.taskcluster.yml` hash in xpi-manifest.