### PR TITLE
chore(azure): bump windows 1.3.3 and win11 25h2 1.0.3 image versions

### DIFF
--- a/worker-images.yml
+++ b/worker-images.yml
@@ -115,22 +115,22 @@ ronin_b1_windows2022_64_2009_alpha:
     name: win2022_64_2009_alpha
 ronin_b1_windows2022_64_2009:
   azure2:
-    version: 1.3.1
+    version: 1.3.3
     resource_group: rg-packer-worker-images
-    deployment_id: "0e15b55"
+    deployment_id: "71b0588"
     name: win2022_64_2009
 ronin_b3_windows2022_64_2009:
   azure_trusted:
-    version: 1.3.1
+    version: 1.3.3
     resource_group: rg-packer-worker-images
-    deployment_id: "0e15b55"
+    deployment_id: "71b0588"
     name: trusted_win2022_64_2009
 # Windows 10
 ronin_t_windows10_64_2009_prod:
   azure2:
-    version: 1.3.1
+    version: 1.3.3
     resource_group: rg-packer-worker-images
-    deployment_id: "0e15b55"
+    deployment_id: "71b0588"
     name: win10_64_2009
 ronin_t_windows10_64_2009_alpha:
   azure2:
@@ -141,9 +141,9 @@ ronin_t_windows10_64_2009_alpha:
 # Windows 11
 win11a6425h2builder:
   azure2:
-    version: 1.0.2
+    version: 1.0.3
     resource_group: rg-packer-worker-images
-    deployment_id: "0e15b55"
+    deployment_id: "71b0588"
     name: win11_a64_25h2_builder
 win11a6425h2builderalpha:
   azure2:
@@ -153,9 +153,9 @@ win11a6425h2builderalpha:
     name: win11_a64_25h2_builder_alpha
 trusted_win11_a64_25h2_builder:
   azure_trusted:
-    version: 1.0.2
+    version: 1.0.3
     resource_group: rg-packer-worker-images
-    deployment_id: "0e15b55"
+    deployment_id: "71b0588"
     name: trusted_win11_a64_25h2_builder
 ronin_b1_windows11_a64_24h2_builder_alpha:
   azure2:
@@ -165,15 +165,15 @@ ronin_b1_windows11_a64_24h2_builder_alpha:
     name: win11_a64_24h2_builder_alpha
 ronin_b1_windows11_a64_24h2_builder:
   azure2:
-    version: 1.3.1
+    version: 1.3.3
     resource_group: rg-packer-worker-images
-    deployment_id: "0e15b55"
+    deployment_id: "71b0588"
     name: win11_a64_24h2_builder
 ronin_b3_windows11_a64_24h2_builder:
   azure_trusted:
-    version: 1.3.1
+    version: 1.3.3
     resource_group: rg-packer-worker-images
-    deployment_id: "0e15b55"
+    deployment_id: "71b0588"
     name: trusted_win11_a64_24h2_builder
 ronin_t_windows11_a64_24h2_tester_alpha:
   azure2:
@@ -183,15 +183,15 @@ ronin_t_windows11_a64_24h2_tester_alpha:
     name: win11_a64_24h2_tester_alpha
 ronin_t_windows11_a64_24h2_tester:
   azure2:
-    version: 1.3.1
+    version: 1.3.3
     resource_group: rg-packer-worker-images
-    deployment_id: "0e15b55"
+    deployment_id: "71b0588"
     name: win11_a64_24h2_tester
 win11a6425h2tester:
   azure2:
-    version: 1.0.2
+    version: 1.0.3
     resource_group: rg-packer-worker-images
-    deployment_id: "0e15b55"
+    deployment_id: "71b0588"
     name: win11_a64_25h2_tester
 win11a6425h2testeralpha:
   azure2:
@@ -201,9 +201,9 @@ win11a6425h2testeralpha:
     name: win11_a64_25h2_tester_alpha
 ronin_t_windows11_64_24h2:
   azure2:
-    version: 1.3.2
+    version: 1.3.3
     resource_group: rg-packer-worker-images
-    deployment_id: "7c150a4"
+    deployment_id: "71b0588"
     name: win11_64_24h2
 ronin_t_windows11_64_24h2_alpha:
   azure2:
@@ -213,9 +213,9 @@ ronin_t_windows11_64_24h2_alpha:
     name: win11_64_24h2_alpha
 win116425h2:
   azure2:
-    version: 1.0.2
+    version: 1.0.3
     resource_group: rg-packer-worker-images
-    deployment_id: "7c150a4"
+    deployment_id: "71b0588"
     name: win11_64_25h2
 win116425h2alpha:
   azure2:


### PR DESCRIPTION
## Summary
- Bumps the **Windows 24H2 family** (plus Win10 22H2 and Windows Server 2022) to image version `1.3.3` and the **Win11 25H2 family** (testers and builders, including `trusted_win11_a64_25h2_builder`) to image version `1.0.3`. Both families now deploy from `ronin_puppet` `master` at commit [`71b0588`](https://github.com/mozilla-platform-ops/ronin_puppet/commit/71b0588) (`RELOPS-2317 - bump taskcluster cloud worker version to 99.2.0`).
- **Taskcluster generic-worker** on Windows is back to **`99.2.0`** across `GenericWorker`, `LiveLog`, `StartWorker`, and `Proxy`. It was temporarily rolled back to `96.2.3` in [`7c150a4`](https://github.com/mozilla-platform-ops/ronin_puppet/commit/7c150a4) for `RELOPS-2349` 25H2 troubleshooting; this re-pins it.
- Built by [worker-images run #25438446858](https://github.com/mozilla-platform-ops/worker-images/actions/runs/25438446858) against `worker-images@0ea9ee4`.
- Follow-up to #955.

## ronin_puppet commits

### Range (`0e15b55...71b0588`) — Windows-relevant
| Commit | Description |
|---|---|
| [`71b0588`](https://github.com/mozilla-platform-ops/ronin_puppet/commit/71b0588) | RELOPS-2317 - bump taskcluster cloud worker version to 99.2.0 (#1201) |
| [`edef6331`](https://github.com/mozilla-platform-ops/ronin_puppet/commit/edef6331) | RELOPS-2321 - update xperf command (#1197) |
| [`7c150a4`](https://github.com/mozilla-platform-ops/ronin_puppet/commit/7c150a4) | RELOPS-2349: Windows 11 25H2 1.0.2 image troubleshooting (#1196) |
| [`f165a210`](https://github.com/mozilla-platform-ops/ronin_puppet/commit/f165a210) | RELOPS-2321 - collect all xperf profiling data then publish ETL file (#1192) |

[Full compare](https://github.com/mozilla-platform-ops/ronin_puppet/compare/0e15b55...71b0588)