### PR TITLE
fix: gecko-3-balrog-mozcloud worker id

### DIFF
--- a/clients.yml
+++ b/clients.yml
@@ -652,7 +652,7 @@ project/releng/scriptworker/v2/balrog/prod/firefoxci-gecko-3-mozcloud:
   description: ''
   scopes:
     - queue:claim-work:scriptworker-k8s/gecko-3-balrog-mozcloud
-    - queue:worker-id:gecko-3-balrog/gecko-3-balrog-mozcloud-*
+    - queue:worker-id:gecko-3-balrog-mozcloud/gecko-3-balrog-mozcloud-*
 project/releng/scriptworker/v2/balrog/dev/firefoxci-xpi-1:
   description: ''
   scopes:


### PR DESCRIPTION
This is slightly different than I anticipated it would be, and these workers are throwing scope errors.