### PR TITLE
Bug 2028701 - grants: allow docker os-group scope to reviewer-selector pull requests

### DIFF
--- a/grants.d/grants.yml
+++ b/grants.d/grants.yml
@@ -2364,3 +2364,10 @@
     - project:
         alias: mozilla-release
         job: action:merge-automation
+
+- grant:
+    - generic-worker:os-group:<..>/docker
+  to:
+    - project:
+        alias: reviewer-selector
+        job: action:github-pull-request

--- a/grants.d/grants.yml
+++ b/grants.d/grants.yml
@@ -2366,7 +2366,7 @@
         job: action:merge-automation
 
 - grant:
-    - generic-worker:os-group:<..>/docker
+    - generic-worker:os-group:{trust_domain}-t/t-linux-*/docker
   to:
     - project:
         alias: reviewer-selector


### PR DESCRIPTION
This is necessary to build the docker image based on PRs and pushes.