### PR TITLE
RELOPS-2358: add mozilla-t 2404 Wayland relsre pool

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -2174,6 +2174,7 @@ pools:
     provider_id: fxci-level1-gcp
     variants:
       - pool-group: gecko-t
+      - pool-group: mozilla-t
     config:
       minCapacity: 0
       maxCapacity: 10


### PR DESCRIPTION
## Summary
- Add a `mozilla-t` variant for `t-linux-2404-wayland-relsre`.
- This creates `mozilla-t/t-linux-2404-wayland-relsre` pointing at the existing Ubuntu 24.04 Wayland GUI alpha image mapping.

## Context
This is for [RELOPS-2358](https://mozilla-hub.atlassian.net/browse/RELOPS-2358), so fx-desktop QA automation can test against the Wayland GUI alpha image without using the production `mozilla-t/t-linux-2404-wayland` pool.

Related work so far:
- mozilla/fx-desktop-qa-automation#1294 - Ben's PyAutoGUI branch.
- mozilla/fx-desktop-qa-automation#1310 - Xauthority follow-up/probe for the PyAutoGUI import path.
- mozilla-platform-ops/worker-images#773 - adds `python3-tk` and `python3-dev` to the Wayland GUI alpha image.
- https://github.com/mozilla-platform-ops/worker-images/actions/runs/25741008672 - alpha image build for `gw-fxci-gcp-l1-2404-gui-alpha`.

## Testing
- Not run locally. GitHub PR checks will run `tc-admin check` for the target environments.
