### PR TITLE
fix: bump maxCapacity for enterprise linux test pools

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -4326,6 +4326,10 @@ pools:
             by-suffix:
               .*2404-wayland.*: 100
               default: 2500
+          enterprise-t:
+            by-suffix:
+              docker(-noscratch)?-amd: 200
+              default: 100
           default: 100
       implementation: "{implementation}"
       regions:


### PR DESCRIPTION
We're starting to get backlogs.