### PR TITLE
Bug 2037572 - Add missing Enterprise Windows worker pools

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -3124,6 +3124,7 @@ pools:
       implementation: generic-worker/windows
     variants:
       - pool-group: gecko-t
+      - pool-group: enterprise-t
       - pool-group: gecko-t
         suffix: gpu
       - pool-group: gecko-t
@@ -3148,7 +3149,7 @@ pools:
           default: ronin_t_windows10_64_2009_prod
       image_resource_group: rg-packer-through-cib
       implementation: '{implementation}'
-      worker-purpose: gecko-t
+      worker-purpose: '{pool-group}'
       locations:
         by-suffix:
           alpha: [west-us-3, east-us, east-us-2, west-us-2, west-us]
@@ -3156,10 +3157,13 @@ pools:
           (webgpu|gpu)(-alpha)?: [west-us-3, east-us, east-us-2, west-us, west-us-2]
           default: [canada-central, central-india, east-us, east-us-2, west-us, west-us-2, west-us-3, north-central-us, central-us, north-europe, south-india]
       maxCapacity:
-        by-suffix:
-          '': 600
-          alpha: 500
-          default: 100
+        by-pool-group:
+          enterprise-t: 200
+          default:
+            by-suffix:
+              '': 600
+              alpha: 500
+              default: 100
       armDeployment:
         templateSpecId: /subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template/versions/1.0
       worker-config:
@@ -3598,10 +3602,14 @@ pools:
         implementation: generic-worker/windows
       - pool-group: gecko-t
         suffix: large
+      - pool-group: enterprise-t
+        suffix: large
       - pool-group: gecko-t
         suffix: large-alpha
         implementation: generic-worker/windows
       - pool-group: gecko-t
+        suffix: gpu
+      - pool-group: enterprise-t
         suffix: gpu
       - pool-group: gecko-t
         suffix: gpu-alpha
@@ -3665,7 +3673,7 @@ pools:
               alpha: 500
               gpu: 600
               default: 100
-          enterprise-t: 300
+          enterprise-t: 200
           default: 5
       armDeployment:
         templateSpecId: /subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template/versions/1.0
@@ -3820,6 +3828,8 @@ pools:
       - pool-group: gecko-t
       - pool-group: gecko-t
         suffix: privileged
+      - pool-group: enterprise-t
+        suffix: privileged
       - pool-group: gecko-t
         suffix: unprivileged
       - pool-group: gecko-t
@@ -3833,14 +3843,20 @@ pools:
         implementation: generic-worker/windows
       - pool-group: gecko-t
         suffix: large
+      - pool-group: enterprise-t
+        suffix: large
       - pool-group: gecko-t
         suffix: large-alpha
         implementation: generic-worker/windows
       - pool-group: gecko-t
         suffix: gpu
+      - pool-group: enterprise-t
+        suffix: gpu
       - pool-group: gecko-t
         suffix: gpu-alpha
       - pool-group: gecko-t
+        suffix: webgpu
+      - pool-group: enterprise-t
         suffix: webgpu
       - pool-group: gecko-t
         suffix: webgpu-alpha
@@ -3899,7 +3915,7 @@ pools:
               alpha: 500
               gpu: 600
               default: 100
-          enterprise-t: 300
+          enterprise-t: 200
           default: 5
       armDeployment:
         templateSpecId: /subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template/versions/1.0


### PR DESCRIPTION
## Summary
- Add missing `enterprise-t` Windows worker pool variants used by Enterprise Firefox taskgraphs.
- Cover current queued pools: `win10-64-2009`, `win11-64-25h2-gpu`, and `win11-64-25h2-large`.
- Cover the other Windows pools present in the full Enterprise Firefox graph but absent from worker-manager: `win11-64-24h2-gpu`, `win11-64-24h2-large`, `win11-64-25h2-privileged`, and `win11-64-25h2-webgpu`.
- Set Enterprise Windows maxCapacity to `200`, matching the Enterprise Linux precedent from https://github.com/mozilla-releng/fxci-config/pull/991.

## Context
- Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=2037572.
- Original Enterprise Windows worker pool support: https://github.com/mozilla-releng/fxci-config/pull/730.
- Capacity precedent for Enterprise Linux test pools: https://github.com/mozilla-releng/fxci-config/pull/991.

## Validation
- `uv run fxci generate-worker-pools --environment firefoxci --grep "^enterprise-t/win10|^enterprise-t/win11" --yaml`
- Compared the generated pool ids against the Enterprise Firefox full task graph; no `enterprise-t/win*` queues were missing.
- `uv run pytest tests/ciadmin/test_generate_worker_pools.py`