### PR TITLE
Bug 2037899 - Add missing Enterprise Linux worker pools and grants

### DIFF
--- a/grants.d/enterprise.yml
+++ b/grants.d/enterprise.yml
@@ -36,6 +36,15 @@
         trust_domain: enterprise
 
 - grant:
+    # Snap tests on Enterprise Wayland pools need sudo access to manage snapd.
+    - generic-worker:os-group:enterprise-t/t-linux-2204-wayland-snap/snap_sudo
+    - generic-worker:os-group:enterprise-t/t-linux-2404-wayland-snap/snap_sudo
+  to:
+    - project:
+        feature: gecko-roles
+        trust_domain: enterprise
+
+- grant:
     # Grant some Gecko build secrets to Enterprise Firefox as the values for both
     # will be the same regardless.
     - secrets:get:project/releng/gecko/build/level-{level}/gecko-symbol-upload

--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -2110,6 +2110,10 @@ pools:
         suffix: '-snap'
       - pool-group: mozilla-t
         suffix: ''
+      - pool-group: enterprise-t
+        suffix: ''
+      - pool-group: enterprise-t
+        suffix: '-snap'
     description: Worker for Wayland on Ubuntu 22.04
     owner: release+tc-workers@mozilla.com
     email_on_error: false
@@ -2307,6 +2311,7 @@ pools:
   - pool_id: '{pool-group}/t-linux-xlarge-2204-wayland'  # Bug 1903073
     variants:
       - pool-group: gecko-t
+      - pool-group: enterprise-t
     description: Worker for Wayland on Ubuntu 22.04
     owner: release+tc-workers@mozilla.com
     email_on_error: false
@@ -4262,6 +4267,7 @@ pools:
       - pool-group: comm-t
       - pool-group: mozilla-t
       - pool-group: nss-t
+      - pool-group: enterprise-t
       # D2G / Intel / noscratch
       - pool-group: gecko-t
         suffix: 'docker-noscratch'
@@ -4316,6 +4322,10 @@ pools:
       - pool-group: gecko-t
         # This is a separate pool from above as it's granted privileged
         # os-groups.
+        suffix: '2404-wayland-snap'
+        implementation: generic-worker/linux
+        instance_types: [*c2-standard-4-60gb]
+      - pool-group: enterprise-t
         suffix: '2404-wayland-snap'
         implementation: generic-worker/linux
         instance_types: [*c2-standard-4-60gb]
@@ -4376,14 +4386,20 @@ pools:
       regions: [us-central1, us-east1]
       image: ubuntu-2404-headless-alpha
       instance_types: []
-  - pool_id: 'gecko-t/t-linux-docker-kvm'
+  - pool_id: '{pool-group}/t-linux-docker-kvm'
     description: Worker for gecko-based automation.
     owner: release+tc-workers@mozilla.com
+    variants:
+      - pool-group: gecko-t
+      - pool-group: enterprise-t
     email_on_error: true
     provider_id: fxci-level1-gcp
     config:
       minCapacity: 0
-      maxCapacity: 1600
+      maxCapacity:
+        by-pool-group:
+          gecko-t: 1600
+          enterprise-t: 100
       regions: *default-gcp-regions
       image: ubuntu-2404-headless
       implementation: generic-worker/linux-d2g


### PR DESCRIPTION
## Summary
- Add the missing `enterprise-t` Linux worker pools referenced by the expanded Enterprise Firefox task graph: `t-linux-2204-wayland`, `t-linux-2204-wayland-snap`, `t-linux-xlarge-2204-wayland`, `t-linux-docker`, `t-linux-2404-wayland-snap`, and `t-linux-docker-kvm`.
- Add Enterprise `snap_sudo` grants for the new Wayland snap pools.
- Preserve the existing `gecko-t/t-linux-docker-kvm` capacity while capping the new Enterprise KVM pool at `100`.
- Keep the other new Enterprise Linux pools at the comparable existing Linux default of `100`; the AMD docker pools already use `200` from the Enterprise Linux capacity bump.

## Context
- Enterprise Firefox workload expansion: https://github.com/mozilla/enterprise-firefox/pull/868.
- This is the first Enterprise-specific `snap_sudo` grant for these pools. The comparable Gecko grants were added in:
  - 22.04 Wayland snap: https://phabricator.services.mozilla.com/D212678.
  - 24.04 Wayland snap: https://github.com/mozilla-releng/fxci-config/pull/131.
- Related fxci-config pool support:
  - Enterprise misc pool: https://github.com/mozilla-releng/fxci-config/pull/665.
  - Original Enterprise Windows test pools: https://github.com/mozilla-releng/fxci-config/pull/730.
  - Enterprise Linux high-cpu pool: https://github.com/mozilla-releng/fxci-config/pull/732.
  - Enterprise Linux noscratch AMD pool: https://github.com/mozilla-releng/fxci-config/pull/733.
  - Shared Linux test-pool consolidation: https://github.com/mozilla-releng/fxci-config/pull/734.
  - Windows 11 25H2 pool templates: https://github.com/mozilla-releng/fxci-config/pull/825.
  - Enterprise Linux test-pool capacity bump: https://github.com/mozilla-releng/fxci-config/pull/991.
  - Missing Enterprise Windows pools: https://github.com/mozilla-releng/fxci-config/pull/992.

## Validation
- `uv run fxci generate-worker-pools --environment firefoxci --grep "^enterprise-t/t-linux-(2204-wayland|xlarge-2204-wayland|docker$|docker-kvm|2404-wayland-snap)" --yaml`
- Compared generated `enterprise-t/*` pool ids against the Enterprise Firefox PR #868 full task graph; no missing `enterprise-t/*` pools remain.
- Verified generated Enterprise roles include `generic-worker:os-group:enterprise-t/t-linux-2204-wayland-snap/snap_sudo` and `generic-worker:os-group:enterprise-t/t-linux-2404-wayland-snap/snap_sudo`.
- `uv run pytest tests/ciadmin/test_generate_worker_pools.py tests/ciadmin/test_generate_grants.py tests/ciadmin/test_generate_ciconfig_grants.py`