### PR TITLE
fix: make pre-commit hook assume anonymous role

### DIFF
--- a/hooks.yml
+++ b/hooks.yml
@@ -159,6 +159,7 @@ lint/pre-commit-{version}:
   owner: release+hooks@mozilla.com
   email_on_error: true
   scopes:
+    - assume:anonymous
     - generic-worker:cache:lint-pre-commit-*
     - queue:create-task:low:mozilla-t/pre-commit
     - queue:route:checks


### PR DESCRIPTION
This works around:
https://github.com/taskcluster/taskcluster/issues/8625

Where TC-Github is attempting to fetch a public artifact, but makes an authenticated request using the hook's scopes. This seems to cause the anonymous scopes to not apply, and we get a scope error.

While we wait for that to get fixed, assume the anonymous role to silence the errors.