### PR TITLE
fix: grant codecoverage route scope to comm-central

### DIFF
--- a/grants.d/grants.yml
+++ b/grants.d/grants.yml
@@ -896,6 +896,7 @@
           - try
           - try-comm-central
           - mozilla-central
+          - comm-central
 
 - grant:
     # Bug 1876393: Allow mozilla-central to trigger tb-rust-update-check on comm-central


### PR DESCRIPTION
comm-central decision tasks were failing with InsufficientScopes when creating code-coverage-artifacts tasks. Mirror the existing mozilla-central grant for queue:route:project.codecoverage.v1.tasks_done.