### PR TITLE
Bug 1941642 - Add -alpha wayland pools to validate Ubuntu 24.04 candidate images

### DIFF
--- a/grants.d/grants.yml
+++ b/grants.d/grants.yml
@@ -270,7 +270,8 @@
     - generic-worker:os-group:gecko-t/win11-64-24h2-source/Administrators
     - generic-worker:os-group:gecko-t/t-linux-2204-wayland-snap/snap_sudo
     - generic-worker:os-group:gecko-t/t-linux-2404-wayland-snap/snap_sudo
-    - generic-worker:os-group:gecko-t/t-linux-2404-wayland-relsre/snap_sudo
+    - generic-worker:os-group:gecko-t/t-linux-2404-wayland-snap-alpha/snap_sudo
+    - generic-worker:os-group:gecko-t/t-linux-2404-wayland-alpha/snap_sudo
     - generic-worker:run-as-administrator:gecko-t/win10-64-2009-source
     - generic-worker:run-as-administrator:gecko-t/win11-64-2009-alpha
     - generic-worker:run-as-administrator:gecko-t/win11-64-24h2-alpha

--- a/grants.d/grants.yml
+++ b/grants.d/grants.yml
@@ -271,7 +271,6 @@
     - generic-worker:os-group:gecko-t/t-linux-2204-wayland-snap/snap_sudo
     - generic-worker:os-group:gecko-t/t-linux-2404-wayland-snap/snap_sudo
     - generic-worker:os-group:gecko-t/t-linux-2404-wayland-snap-alpha/snap_sudo
-    - generic-worker:os-group:gecko-t/t-linux-2404-wayland-alpha/snap_sudo
     - generic-worker:run-as-administrator:gecko-t/win10-64-2009-source
     - generic-worker:run-as-administrator:gecko-t/win11-64-2009-alpha
     - generic-worker:run-as-administrator:gecko-t/win11-64-24h2-alpha

--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -2171,14 +2171,33 @@ pools:
           disks:
             - *persistent-disk-60gb
           machine_type: t2a-standard-4
-  - pool_id: '{pool-group}/t-linux-2404-wayland-relsre'
-    description: Workers for Wayland on Ubuntu 24.04. Used by RelSRE to qualify images.
+  - pool_id: '{pool-group}/t-linux-2404-wayland-alpha'
+    description: Workers for Wayland on Ubuntu 24.04. Used to qualify candidate images.
     owner: release+tc-workers@mozilla.com
     email_on_error: true
     provider_id: fxci-level1-gcp
     variants:
       - pool-group: gecko-t
       - pool-group: mozilla-t
+    config:
+      minCapacity: 0
+      maxCapacity: 10
+      implementation: generic-worker/linux
+      regions: *default-gcp-regions
+      image: relsre-gw-fxci-gcp-2404-amd64-gui-alpha
+      instance_types:
+        - minCpuPlatform: Intel Cascadelake
+          disks:
+            - *persistent-disk-60gb
+          machine_type: c2-standard-4
+  - pool_id: '{pool-group}/t-linux-2404-wayland-snap-alpha'
+    description: Workers for Wayland snap tests on Ubuntu 24.04. Used to qualify candidate images.
+    owner: release+tc-workers@mozilla.com
+    email_on_error: true
+    provider_id: fxci-level1-gcp
+    variants:
+      - pool-group: gecko-t
+      - pool-group: enterprise-t
     config:
       minCapacity: 0
       maxCapacity: 10


### PR DESCRIPTION
## Summary

- Renames `{pool-group}/t-linux-2404-wayland-relsre` → `t-linux-2404-wayland-alpha` so it lines up with the `-alpha` convention used by Windows validation pools. worker-images' `run-integration-tests` cron rewrites `<workerType>` → `<workerType>-alpha` to land os-integration tasks on candidate-image pools, and the old `-relsre` suffix made that auto-routing miss.
- Adds a new `{pool-group}/t-linux-2404-wayland-snap-alpha` pool using the same `relsre-gw-fxci-gcp-2404-amd64-gui-alpha` image. Variants are `gecko-t` + `enterprise-t` to mirror the prod `t-linux-2404-wayland-snap` pool.
- Updates the `snap_sudo` os-group grant in `grants.d/grants.yml` to cover both new pool names and drops the `-relsre` entry.

## Context

Gecko-side bug 1941642 landed as autoland `0ef817f332d2`, which adds the Wayland 24.04 snap tests (`snap-upstream-test-basic-2404-amd64-nightly/opt`) to `target_tasks_method: os-integration`. With this fxci-config change, the worker-images `run-integration-tests` cron can validate a new Wayland 24.04 image candidate end-to-end without any extra worker-images plumbing or manual `mach try` overrides — the snap test will route to the new `-snap-alpha` pool running the alpha image.

## Test plan

- [ ] tc-admin diff on staging shows the renamed and new pools, no other drift.
- [ ] Trigger `worker-images:cron:run-integration-tests` with the next Wayland 24.04 image candidate and confirm `snap-upstream-test-basic-2404-amd64-nightly/opt` lands on `gecko-t/t-linux-2404-wayland-snap-alpha`.