### PR TITLE
Grant snap_sudo on wayland-snap-alpha to os-integration consumers

### DIFF
--- a/grants.d/releng.yml
+++ b/grants.d/releng.yml
@@ -139,6 +139,7 @@
     - project:releng:services/tooltool/api/download/internal
     - queue:get-artifact:project/gecko/android-emulator/*
     - queue:get-artifact:project/gecko/android-system-images/*
+    - generic-worker:os-group:gecko-t/t-linux-2404-wayland-snap-alpha/snap_sudo
     # Similarly, we grant enough scopes to be able to run translations training actions
     - assume:repo:github.com/mozilla/translations:action:train
     - queue:create-task:low:translations-1/decision-gcp


### PR DESCRIPTION
## Summary

Adds `generic-worker:os-group:gecko-t/t-linux-2404-wayland-snap-alpha/snap_sudo` to the `&os-integration` grant in `grants.d/releng.yml`. That grant feeds both:

- `fxci-config:pull-request:trusted` (staging mirror)
- `worker-images:cron:run-integration-tests` (image-validation cron)

The worker-images `change_worker_pool_to_alpha` transform retargets the snap test from prod `gecko-t/t-linux-2404-wayland-snap` to `-snap-alpha` and (with mozilla-platform-ops/worker-images#780) rewrites the pool-bound scope to match. Without this grant the decision task gets 403 InsufficientScopes when creating the rewritten task.

Surfaced live by:

```
Client ID task-client/SDjGycEDTK6Ozbmf_H4-Pw/0/...
missing generic-worker:os-group:gecko-t/t-linux-2404-wayland-snap/snap_sudo
```

(via run [25930053384](https://github.com/mozilla-platform-ops/worker-images/actions/runs/25930053384))

#998 already covered the gecko-trunk-side grant (so normal mozilla-central scheduling can create snap-alpha tasks). This handles the worker-images-cron-side need.

## Test plan

- [x] Land alongside mozilla-platform-ops/worker-images#780.
- [ ] Re-run `gcp-fxci-parallel-alpha.yml` and confirm `snap-upstream-test-basic-2404-amd64-nightly/opt` is created successfully against the `gw-fxci-gcp-l1-2404-gui-alpha` image.