### PR TITLE
Bug 2039391 - Add gecko-t/win11-64-25h2-gpu-perf-experiment pool locked to west-us-3

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -3879,6 +3879,8 @@ pools:
       - pool-group: gecko-t
         suffix: gpu-alpha
       - pool-group: gecko-t
+        suffix: gpu-perf-experiment
+      - pool-group: gecko-t
         suffix: webgpu
       - pool-group: enterprise-t
         suffix: webgpu
@@ -3922,6 +3924,7 @@ pools:
               default: [canada-central, east-us, east-us-2, west-us, west-us-2, west-us-3, north-central-us, central-us, north-europe, south-india]
           default:
             by-suffix:
+              gpu-perf-experiment: [west-us-3]
               (source-)?alpha: [west-us-3, east-us, east-us-2, west-us-2, west-us]
               (webgpu|gpu)(-alpha)?: [west-us-3, east-us, west-us, west-us-2]
               (ssd|source): [west-us-3, east-us, east-us-2, west-us, west-us-2, north-central-us, central-us]
@@ -3938,6 +3941,7 @@ pools:
               '': 1200
               alpha: 500
               gpu: 600
+              gpu-perf-experiment: 600
               default: 100
           enterprise-t: 200
           default: 5


### PR DESCRIPTION
## Summary

- Adds a new Azure worker pool `gecko-t/win11-64-25h2-gpu-perf-experiment` as a variant of the `win11-64-25h2` template.
- Pinned to a single region (`west-us-3`) so perf measurements aren't muddied by cross-region variation. VM size resolves to `Standard_NV12ads_A10_v5` (matches the gpu sibling via the existing `.*gpu.*` regex), image `win116425h2`, maxCapacity `600`.
- Intended as a sandbox for testing and experimenting with ideas to run typical Windows hardware tasks in Azure.

Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=2039391

## Test plan

- [ ] `tc-admin diff --environment=firefoxci --grep gecko-t/win11-64-25h2-gpu-perf-experiment` shows only the new pool being added
- [ ] In-tree pytest suite passes (`uv run pytest tests/`) — verified locally (148 passed)
- [ ] After landing, confirm the new worker pool appears in worker-manager and provisions in `west-us-3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)