### PR TITLE
gecko-3/b-win2022: swap eastus2 for southcentralus

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -3040,18 +3040,33 @@ pools:
       worker-manager-config:
         capacityPerInstance: 1
         initialWeight:
-          by-vmSize:
-            Standard_D32ads_v5:
-              by-location:
-                central-india: 1
-                north-central-us: 0.9
-                east-us-2: 0.8
-            Standard_D96ads_v5:
-              by-location:
-                central-india: 1
-                north-central-us: 0.9
-                east-us-2: 0.8
-            default: 1
+          by-pool-id:
+            gecko-3/b-win2022:
+              by-vmSize:
+                Standard_D32ads_v5:
+                  by-location:
+                    central-india: 1
+                    north-central-us: 0.9
+                    south-central-us: 0.8
+                Standard_D96ads_v5:
+                  by-location:
+                    central-india: 1
+                    north-central-us: 0.9
+                    south-central-us: 0.8
+                default: 1
+            default:
+              by-vmSize:
+                Standard_D32ads_v5:
+                  by-location:
+                    central-india: 1
+                    north-central-us: 0.9
+                    east-us-2: 0.8
+                Standard_D96ads_v5:
+                  by-location:
+                    central-india: 1
+                    north-central-us: 0.9
+                    east-us-2: 0.8
+                default: 1
   - pool_id: nss-1/b-win2022-alpha
     description: ''
     owner: relops-azure-provisioning@mozilla.com

--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -2973,16 +2973,7 @@ pools:
         by-suffix:
           .*headless.*: generic-worker/windows-builder
           default: generic-worker/windows
-      locations:
-        by-pool-group:
-          gecko-3:
-            by-chain-of-trust:
-              trusted:
-                by-suffix:
-                  '': [central-india, north-central-us, south-central-us]
-                  default: [central-india, north-central-us, east-us-2]
-              default: [central-india, north-central-us, east-us-2]
-          default: [central-india, north-central-us, east-us-2]
+      locations: [central-india, north-central-us, south-central-us]
       maxCapacity:
         by-pool-group:
           gecko-.*: 500
@@ -3040,33 +3031,18 @@ pools:
       worker-manager-config:
         capacityPerInstance: 1
         initialWeight:
-          by-pool-id:
-            gecko-3/b-win2022:
-              by-vmSize:
-                Standard_D32ads_v5:
-                  by-location:
-                    central-india: 1
-                    north-central-us: 0.9
-                    south-central-us: 0.8
-                Standard_D96ads_v5:
-                  by-location:
-                    central-india: 1
-                    north-central-us: 0.9
-                    south-central-us: 0.8
-                default: 1
-            default:
-              by-vmSize:
-                Standard_D32ads_v5:
-                  by-location:
-                    central-india: 1
-                    north-central-us: 0.9
-                    east-us-2: 0.8
-                Standard_D96ads_v5:
-                  by-location:
-                    central-india: 1
-                    north-central-us: 0.9
-                    east-us-2: 0.8
-                default: 1
+          by-vmSize:
+            Standard_D32ads_v5:
+              by-location:
+                central-india: 1
+                north-central-us: 0.9
+                south-central-us: 0.8
+            Standard_D96ads_v5:
+              by-location:
+                central-india: 1
+                north-central-us: 0.9
+                south-central-us: 0.8
+            default: 1
   - pool_id: nss-1/b-win2022-alpha
     description: ''
     owner: relops-azure-provisioning@mozilla.com

--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -2973,7 +2973,16 @@ pools:
         by-suffix:
           .*headless.*: generic-worker/windows-builder
           default: generic-worker/windows
-      locations: [central-india, north-central-us, east-us-2]
+      locations:
+        by-pool-group:
+          gecko-3:
+            by-chain-of-trust:
+              trusted:
+                by-suffix:
+                  '': [central-india, north-central-us, south-central-us]
+                  default: [central-india, north-central-us, east-us-2]
+              default: [central-india, north-central-us, east-us-2]
+          default: [central-india, north-central-us, east-us-2]
       maxCapacity:
         by-pool-group:
           gecko-.*: 500


### PR DESCRIPTION
## Summary

3-line swap of `east-us-2` -> `south-central-us` in the `b-win2022` pool template (`locations` + two `initialWeight.by-location` entries for `Standard_D32ads_v5` and `Standard_D96ads_v5`). Applies to all 17 generated b-win2022 variants across gecko-1/2/3, comm, mozilla, mozillavpn, nss, enterprise pool-groups. `south-central-us` inherits east-us-2's 0.8 initialWeight.

## Why

| Signal | east-us-2 | south-central-us |
|---|---|---|
| 28d Spot eviction (ARG SpotResources, D32ads_v5) | 20%+ (worst band) | 15-20% |
| Linux Spot $/hr | $0.5457 | $0.3655 |

east-us-2 is the only configured region in the 20%+ band, and is the most expensive Linux Spot region for this SKU across all of Azure. Worker-manager errors on `gecko-3/b-win2022` (May 11-18) concentrate "Operation execution has been preempted by a more recent operation" in east-us-2.

The b-win2022 Compute Gallery images (level-1 and trusted level-3, latest versions) are already replicated to South Central US -- no Packer rebuild.

## Quotas

- **L3 Trusted FXCI**: south-central-us `LowPriorityCores` was 3,000 (peers: 4,000). Bump filed: Azure ticket **2605180040009652** (Sev A).
- **L1 FXCI DevTest**: south-central-us is 3,200 vs peers 7,200. Known follow-up; will file separately. Current L1 b-win2022 demand sits well under the 3,200 cap.

## Test plan

- [x] pytest: 181 passed
- [x] `tc-admin check --environment=firefoxci`: 74 passed, 1 skipped, 0 failed
- [x] pre-commit: passed
- [x] All 17 variants verified: `locations` resolves to `[central-india, north-central-us, south-central-us]`, `initialWeight` to `[1, 0.9, 0.8]`, no `east-us-2` remaining