### PR TITLE
RELOPS-2376: use dedicated host template for SP3 experiment

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -3941,12 +3941,18 @@ pools:
               '': 1200
               alpha: 500
               gpu: 600
-              gpu-perf-experiment: 600
+              gpu-perf-experiment: 6
               default: 100
           enterprise-t: 200
           default: 5
       armDeployment:
-        templateSpecId: /subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template/versions/1.0
+        by-suffix:
+          gpu-perf-experiment:
+            templateSpecId: /subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template-dedicated-host/versions/1.0
+            parameters:
+              priority: Regular
+          default:
+            templateSpecId: /subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template/versions/1.0
       worker-config:
         genericWorker:
           config:


### PR DESCRIPTION
## Summary
- Point only `gecko-t/win11-64-25h2-gpu-perf-experiment` at `taskcluster-arm-template-dedicated-host/versions/1.0`
- Pass `priority: Regular` for the dedicated host path
- Cap the experiment pool at 6 workers to match the single `NVadsA10v5_Type1` dedicated host capacity

## Notes
- Based on https://mozilla-hub.atlassian.net/browse/RELOPS-2376
- Depends on publishing the dedicated host template spec version before this pool is exercised
- The dedicated template bakes in the `dhg-west-us-3-gecko-t-sp3-perf` host group from RELOPS-2375

## Validation
- `GITHUB_TOKEN="$(gh auth token)" uv run tc-admin generate --environment=firefoxci --resources=worker_pools --grep 'gecko-t/win11-64-25h2-gpu-perf-experiment' --json`\n- Commit hooks: trailing whitespace, EOF, large file check, yamllint\n