### PR TITLE
fix: include response body when Github is unhappy about GITHUB_TOKEN

### DIFF
--- a/src/ciadmin/generate/branches.py
+++ b/src/ciadmin/generate/branches.py
@@ -4,8 +4,6 @@
 
 from asyncio import Lock
 
-import aiohttp
-
 from ciadmin.util import github
 
 _cache = {}
@@ -39,30 +37,32 @@ async def get(repo_path, repo_type="git"):
             response = await client.request(
                 "GET", branches_endpoint, headers=headers, params=params
             )
-            try:
+            if not response.ok:
+                detail = await response.text()
+                print(
+                    f"Got error when querying {branches_endpoint}: "
+                    f"{response.status} {response.reason}: {detail}"
+                )
                 response.raise_for_status()
-                result = await response.json()
-                branches.extend([b["name"] for b in result])
-                # If `link` is present in the response it will contain
-                # pagination information. We need to examine it to see
-                # if there are additional pages of results to fetch.
-                # See https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api?apiVersion=2022-11-28#using-link-headers
-                # for a full description of the responses.
-                # This icky parsing can probably go away when we switch
-                # to a GitHub app, as we'll likely be using a proper
-                # client at that point.
-                for l in response.headers.get("link", "").split(","):
-                    if 'rel="next"' in l:
-                        branches_endpoint = l.split(">")[0].split("<")[1]
-                        branches_endpoint = branches_endpoint[
-                            len("https://api.github.com") :
-                        ]
-                        break
-                else:
-                    branches_endpoint = None
-            except aiohttp.ClientResponseError as e:
-                print(f"Got error when querying {branches_endpoint}: {e}")
-                raise e
+            result = await response.json()
+            branches.extend([b["name"] for b in result])
+            # If `link` is present in the response it will contain
+            # pagination information. We need to examine it to see
+            # if there are additional pages of results to fetch.
+            # See https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api?apiVersion=2022-11-28#using-link-headers
+            # for a full description of the responses.
+            # This icky parsing can probably go away when we switch
+            # to a GitHub app, as we'll likely be using a proper
+            # client at that point.
+            for l in response.headers.get("link", "").split(","):
+                if 'rel="next"' in l:
+                    branches_endpoint = l.split(">")[0].split("<")[1]
+                    branches_endpoint = branches_endpoint[
+                        len("https://api.github.com") :
+                    ]
+                    break
+            else:
+                branches_endpoint = None
 
         _cache[repo_path] = branches
         return _cache[repo_path]

--- a/tests/ciadmin/test_generate_branches.py
+++ b/tests/ciadmin/test_generate_branches.py
@@ -1,0 +1,76 @@
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+
+from ciadmin.generate import branches as branches_module
+
+
+def make_mock_client(response):
+    client = AsyncMock()
+    client.request = AsyncMock(return_value=response)
+    return client
+
+
+def make_403_response(body_text):
+    response = MagicMock()
+    response.ok = False
+    response.status = 403
+    response.reason = "Forbidden"
+    response.text = AsyncMock(return_value=body_text)
+    response.raise_for_status.side_effect = aiohttp.ClientResponseError(
+        MagicMock(), MagicMock(), status=403
+    )
+    return response
+
+
+@pytest.mark.asyncio
+async def test_get_403_rate_limit_exceeded(capsys):
+    branches_module._cache.clear()
+    body = json.dumps(
+        {
+            "message": "API rate limit exceeded for 1.2.3.4. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)",
+            "documentation_url": "https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting",
+        }
+    )
+    response = make_403_response(body)
+    client = make_mock_client(response)
+
+    with patch(
+        "ciadmin.generate.branches.github.get_client", AsyncMock(return_value=client)
+    ):
+        with pytest.raises(aiohttp.ClientResponseError):
+            await branches_module.get("mozilla-releng/fxci-config")
+
+    captured = capsys.readouterr()
+    assert "403" in captured.out
+    assert "API rate limit exceeded" in captured.out
+
+
+@pytest.mark.asyncio
+async def test_get_403_saml_enforcement(capsys):
+    branches_module._cache.clear()
+    body = json.dumps(
+        {
+            "message": "Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization.",
+            "documentation_url": "https://docs.github.com/articles/authenticating-to-a-github-organization-with-saml-single-sign-on/",
+            "status": "403",
+        }
+    )
+    response = make_403_response(body)
+    client = make_mock_client(response)
+
+    with patch(
+        "ciadmin.generate.branches.github.get_client", AsyncMock(return_value=client)
+    ):
+        with pytest.raises(aiohttp.ClientResponseError):
+            await branches_module.get("taskcluster/taskgraph")
+
+    captured = capsys.readouterr()
+    assert "403" in captured.out
+    assert "SAML enforcement" in captured.out


### PR DESCRIPTION
## Context

I occasionally run `ci-admin`  these days. When I do, I sometimes forget to set the `GITHUB_TOKEN` which I quickly remember thanks to the existing warning. However, I also have to reissue a new token which means the SAML config of my token gets reset. With the current behavior, I have no way of knowing what is wrong with my `GITHUB_TOKEN` except by remembering what I did last time. 

With this PR, I hope that I'll be able to remember faster next time 🙂

## Verification

Without `GITHUB_TOKEN` (rate limit hit):
```
WARNING: GITHUB_TOKEN is not present in the environment; you may run into rate limits querying for GitHub branches
Got error when querying /repos/mozilla-releng/fxci-config/branches: 403 rate limit exceeded: {"message":"API rate limit exceeded for 1.2.3.4. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}
```

With `GITHUB_TOKEN` not SSO-authorized for the `mozilla` org:
```
Got error when querying /repos/taskcluster/taskgraph/branches: 403 Forbidden: {"message":"Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization.","documentation_url":"https://docs.github.com/articles/authenticating-to-a-github-organization-with-saml-single-sign-on/","status":"403"}
```