### PR TITLE
Bug 2041108 - Bump build-decision maxCapacity to 16

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -320,7 +320,7 @@ pools:
     provider_id: fxci-level1-gcp
     config:
       minCapacity: 1
-      maxCapacity: 4
+      maxCapacity: 16
       regions: *default-gcp-regions
       image: monopacker-docker-worker-current
       instance_types:


### PR DESCRIPTION
This should allow two instance to be requested at once (each have capacityPerInstance=8).