### PR TITLE
Bug 2039391 - Increase SP3 perf experiment pool capacity

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -3090,7 +3090,7 @@ pools:
               '': 1200
               alpha: 500
               gpu: 600
-              gpu-perf-experiment: 6
+              gpu-perf-experiment: 12
               default: 100
           enterprise-t: 200
           default: 5


### PR DESCRIPTION
## Summary
- Bump `gecko-t/win11-64-25h2-gpu-perf-experiment` max capacity from 6 to 12

## Context
This follows the second dedicated host added in https://github.com/mozilla-platform-ops/relops_infra_as_code/pull/296.

Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=2039391

## Validation
- pre-commit hooks from `git commit` passed: trailing whitespace, end-of-file, large files, yamllint
- `git diff --check -- worker-pools.yml`
- `GITHUB_TOKEN=$(gh auth token) uv run tc-admin diff --environment firefoxci --grep gecko-t/win11-64-25h2-gpu-perf-experiment` confirmed generated maxCapacity changes from 6 to 12

Note: full `tc-admin check --environment firefoxci` currently fails on unrelated `reviewer-selector` GitHub pull-request policy drift (`public` vs `collaborators`); the worker-pool check section passed (`check_worker_pools.py ....s`).