### PR TITLE
chore(azure): bump windows image versions to 1.3.4 / 1.0.4

### DIFF
--- a/worker-images.yml
+++ b/worker-images.yml
@@ -99,22 +99,22 @@ ronin_b1_windows2022_64_2009_alpha:
     name: win2022_64_2009_alpha
 ronin_b1_windows2022_64_2009:
   azure2:
-    version: 1.3.3
+    version: 1.3.4
     resource_group: rg-packer-worker-images
-    deployment_id: "71b0588"
+    deployment_id: "757b34d"
     name: win2022_64_2009
 ronin_b3_windows2022_64_2009:
   azure_trusted:
-    version: 1.3.3
+    version: 1.3.4
     resource_group: rg-packer-worker-images
-    deployment_id: "71b0588"
+    deployment_id: "757b34d"
     name: trusted_win2022_64_2009
 # Windows 10
 ronin_t_windows10_64_2009_prod:
   azure2:
-    version: 1.3.3
+    version: 1.3.4
     resource_group: rg-packer-worker-images
-    deployment_id: "71b0588"
+    deployment_id: "757b34d"
     name: win10_64_2009
 ronin_t_windows10_64_2009_alpha:
   azure2:
@@ -125,9 +125,9 @@ ronin_t_windows10_64_2009_alpha:
 # Windows 11
 win11a6425h2builder:
   azure2:
-    version: 1.0.3
+    version: 1.0.4
     resource_group: rg-packer-worker-images
-    deployment_id: "71b0588"
+    deployment_id: "757b34d"
     name: win11_a64_25h2_builder
 win11a6425h2builderalpha:
   azure2:
@@ -155,9 +155,9 @@ ronin_b1_windows11_a64_24h2_builder:
     name: win11_a64_24h2_builder
 ronin_b3_windows11_a64_24h2_builder:
   azure_trusted:
-    version: 1.3.3
+    version: 1.3.4
     resource_group: rg-packer-worker-images
-    deployment_id: "71b0588"
+    deployment_id: "757b34d"
     name: trusted_win11_a64_24h2_builder
 ronin_t_windows11_a64_24h2_tester_alpha:
   azure2:
@@ -167,15 +167,15 @@ ronin_t_windows11_a64_24h2_tester_alpha:
     name: win11_a64_24h2_tester_alpha
 ronin_t_windows11_a64_24h2_tester:
   azure2:
-    version: 1.3.3
+    version: 1.3.4
     resource_group: rg-packer-worker-images
-    deployment_id: "71b0588"
+    deployment_id: "757b34d"
     name: win11_a64_24h2_tester
 win11a6425h2tester:
   azure2:
-    version: 1.0.3
+    version: 1.0.4
     resource_group: rg-packer-worker-images
-    deployment_id: "71b0588"
+    deployment_id: "757b34d"
     name: win11_a64_25h2_tester
 win11a6425h2testeralpha:
   azure2:
@@ -185,9 +185,9 @@ win11a6425h2testeralpha:
     name: win11_a64_25h2_tester_alpha
 ronin_t_windows11_64_24h2:
   azure2:
-    version: 1.3.3
+    version: 1.3.4
     resource_group: rg-packer-worker-images
-    deployment_id: "71b0588"
+    deployment_id: "757b34d"
     name: win11_64_24h2
 ronin_t_windows11_64_24h2_alpha:
   azure2:
@@ -197,9 +197,9 @@ ronin_t_windows11_64_24h2_alpha:
     name: win11_64_24h2_alpha
 win116425h2:
   azure2:
-    version: 1.0.3
+    version: 1.0.4
     resource_group: rg-packer-worker-images
-    deployment_id: "71b0588"
+    deployment_id: "757b34d"
     name: win11_64_25h2
 win116425h2alpha:
   azure2:

--- a/worker-images.yml
+++ b/worker-images.yml
@@ -149,9 +149,9 @@ ronin_b1_windows11_a64_24h2_builder_alpha:
     name: win11_a64_24h2_builder_alpha
 ronin_b1_windows11_a64_24h2_builder:
   azure2:
-    version: 1.3.4
+    version: 1.3.3
     resource_group: rg-packer-worker-images
-    deployment_id: "757b34d"
+    deployment_id: "71b0588"
     name: win11_a64_24h2_builder
 ronin_b3_windows11_a64_24h2_builder:
   azure_trusted:

--- a/worker-images.yml
+++ b/worker-images.yml
@@ -137,9 +137,9 @@ win11a6425h2builderalpha:
     name: win11_a64_25h2_builder_alpha
 trusted_win11_a64_25h2_builder:
   azure_trusted:
-    version: 1.0.3
+    version: 1.0.4
     resource_group: rg-packer-worker-images
-    deployment_id: "71b0588"
+    deployment_id: "757b34d"
     name: trusted_win11_a64_25h2_builder
 ronin_b1_windows11_a64_24h2_builder_alpha:
   azure2:
@@ -149,9 +149,9 @@ ronin_b1_windows11_a64_24h2_builder_alpha:
     name: win11_a64_24h2_builder_alpha
 ronin_b1_windows11_a64_24h2_builder:
   azure2:
-    version: 1.3.3
+    version: 1.3.4
     resource_group: rg-packer-worker-images
-    deployment_id: "71b0588"
+    deployment_id: "757b34d"
     name: win11_a64_24h2_builder
 ronin_b3_windows11_a64_24h2_builder:
   azure_trusted:


### PR DESCRIPTION
## Summary
- Bumps 10 of 11 production + trusted Windows configs to ronin_puppet `757b34d` (was `71b0588`).
- 24H2 / Win10 / Win2022 family: `1.3.3 → 1.3.4`.
- 25H2 family: `1.0.3 → 1.0.4`.
- `ronin_b1_windows11_a64_24h2_builder` stays on `1.3.3 / 71b0588` — deferred (see below).

## Deferred config

`win11_a64_24h2_builder` is the one ARM64 builder pool not being bumped here. The packer build for it failed seven consecutive attempts (initial parallel + 6 reruns + a region-pinned `westus2` retry) at puppet's `Enable-WindowsOptionalFeature -FeatureName NetFx3 -All` step. Diagnosis points at a regression introduced by the May 7 ARM64 24H2 marketplace image republish (`26100.8246 → 26100.8457`); the older base image built fine, the newer one doesn't. The other three ARM64 builders all eventually succeeded on the new base image — so it's not a universal break, just unreliable enough that this specific config never landed a clean build.

Plan for the deferred config: pin the Marketplace image version (or stage the NetFx3 SxS cab offline) in a follow-up worker-images PR, then a follow-up fxci-config PR with the missing version bump. Tracked separately.

## ronin_puppet commits in this bump

| sha | message |
| --- | --- |
| `919f6951a98d` | Install pyyaml on macOS M4 test workers (#1203) (#1204) — macOS only |
| `cc4253af20ad` | inventory: add macmini-m4-130 through 149 (#1205) — macOS only |
| `50bf30c1818d` | ci: drop ubuntu -backports from kitchen docker sources (#1212) — CI infra only |
| `757b34d34d03` | **RELOPS-2372: bump NVIDIA A10 GRID driver to 573.96 (vGPU 18.x) (#1218)** |

Only Windows-relevant commit is the NVIDIA A10 GRID driver bump (RELOPS-2372), which applies to GPU test pools and is the user-facing reason for shipping today.

[Full compare](https://github.com/mozilla-platform-ops/ronin_puppet/compare/71b0588...757b34d)
