### PR TITLE
Bug 2037926 - grant file-specific version_bump scopes to staging-xpi-manifest

### DIFF
--- a/grants.d/xpi.yml
+++ b/grants.d/xpi.yml
@@ -107,6 +107,8 @@
 
 - grant:
     - project:releng:lando:action:version_bump
+    - project:releng:lando:action:version_bump:file:browser/extensions/newtab/manifest.json
+    - project:releng:lando:action:version_bump:file:browser/extensions/webcompat/manifest.json
     - project:releng:lando:repo:staging-firefox-main
   to:
     - project:


### PR DESCRIPTION
## Summary

- Adds `project:releng:lando:action:version_bump:file:browser/extensions/newtab/manifest.json` and `project:releng:lando:action:version_bump:file:browser/extensions/webcompat/manifest.json` scopes to `staging-xpi-manifest`
- Keeps the existing general `project:releng:lando:action:version_bump` during the transition period (removed in the cleanup PR)
- Staging-only change; production grants are handled in the cleanup PR

## Merge order

1. This PR (fxci-config staging) — apply-staging + merge
2. [scriptworker-scripts #1448](https://github.com/mozilla-releng/scriptworker-scripts/pull/1448) — deploy to staging via `dev-landoscript`, merge to `master`
3. [fxci-config production #1038](https://github.com/mozilla-releng/fxci-config/pull/1038) — after staging verification
4. [mozilla-taskgraph #215](https://github.com/mozilla-releng/mozilla-taskgraph/pull/215) — merge + publish
5. xpi-manifest — update mozilla-taskgraph pin, trigger staging e2e test
6. firefox gecko_taskgraph — Phabricator + uplift
7. fxci-config cleanup (separate PR) — remove old general `version_bump` grants
8. scriptworker-scripts cleanup (separate PR) — remove transition fallback

## Verification

Apply staging with `/taskcluster apply-staging`, then trigger a staging-xpi-manifest release-promotion (ship phase). Verify the `version-bump-*` task succeeds with the file-specific scopes.

[Bug 2037926](https://bugzilla.mozilla.org/show_bug.cgi?id=2037926)