### PR TITLE
feat: grant create-new-nightly-release scope to gecko-roles

### DIFF
--- a/grants.d/grants.yml
+++ b/grants.d/grants.yml
@@ -302,6 +302,7 @@
     - project:releng:googleplay:product:focus-android:dep
     - project:releng:microsoftstore:mock
     - project:releng:ship-it:action:create-new-release
+    - project:releng:ship-it:action:create-new-nightly-release
     - project:releng:ship-it:action:mark-as-shipped
     - project:releng:ship-it:action:mark-as-started
     - project:releng:ship-it:action:update-product-channel-version
@@ -352,6 +353,7 @@
     - project:releng:flathub:firefox:mock
     - project:releng:microsoftstore:mock
     - project:releng:ship-it:action:create-new-release
+    - project:releng:ship-it:action:create-new-nightly-release
     - project:releng:ship-it:action:mark-as-shipped
     - project:releng:ship-it:action:mark-as-started
     - project:releng:ship-it:action:update-product-channel-version


### PR DESCRIPTION
This is in support of the work to publish first release information in product details (https://bugzilla.mozilla.org/show_bug.cgi?id=2042596).