### PR TITLE
Add west-us-3 to b-win2022 pool locations

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -2122,7 +2122,7 @@ pools:
         by-suffix:
           .*headless.*: generic-worker/windows-builder
           default: generic-worker/windows
-      locations: [central-india, north-central-us, south-central-us]
+      locations: [central-india, north-central-us, south-central-us, west-us-3]
       maxCapacity:
         by-pool-group:
           gecko-.*: 500
@@ -2185,11 +2185,13 @@ pools:
               by-location:
                 central-india: 1
                 north-central-us: 0.9
+                west-us-3: 0.9
                 south-central-us: 0.8
             Standard_D96ads_v5:
               by-location:
                 central-india: 1
                 north-central-us: 0.9
+                west-us-3: 0.9
                 south-central-us: 0.8
             default: 1
   - pool_id: nss-1/b-win2022-alpha


### PR DESCRIPTION
## Summary

- Adds `west-us-3` as a 4th region for all `b-win2022` variants across L1 (gecko-1, gecko-2, comm-1, mozilla-1, mozillavpn-1, nss-1, enterprise-1) and L3 trusted (gecko-3, comm-3, mozilla-3, mozillavpn-3, nss-3, enterprise-3) pool-groups.
- Sets `initialWeight: 0.9` for `west-us-3` on both `Standard_D32ads_v5` and `Standard_D96ads_v5`, matching `north-central-us` (D32ads_v5 spot is currently priced the same in both regions).

## Background

The existing three regions (central-india, north-central-us, south-central-us) are running near the per-region 4000 `lowPriorityCores` cap on the trusted subscription. On `gecko-3/b-win2022` this is producing roughly 12% preflight quota rejections from Azure over the last 24h (~140 failed ARM deployments) — visible in worker-manager logs as `QuotaExceeded` inside `InvalidTemplateDeployment` errors. Spreading load across a 4th region restores headroom without needing quota bumps in the existing three.

`west-us-3` was previously in the `gecko-3` location list and was removed in #537 ("Deploy Windows Image 1.0.8") when the per-pool-group locations split was collapsed for cost. The cost trade-off has shifted now that the picked-for-cost regions are quota-saturated.

## Pre-merge dependency

`west-us-3` VNet + subnet resources are already provisioned in the trusted subscription for all 6 L3 pool-groups, and in the L1 subscription for 4 of 7 pool-groups (gecko-1, mozilla-1, vpn-1, enterprise-1). The remaining 3 L1 pool-groups (gecko-2, comm-1, nss-1) need `terraform apply` in `relops_infra_as_code` first — companion PR coming.

## Test plan

- [x] `tc-admin generate --environment firefoxci --resources worker_pools` resolves `west-us-3` for all 14 b-win2022 variants
- [x] `tc-admin check --environment firefoxci` baseline matches main (no new failures)
- [x] Merge after `relops_infra_as_code` companion PR is applied for gecko-2, comm-1, nss-1
- [x] Confirm worker-manager `worker-error` rate for `QuotaExceeded` drops over the following 24h