### PR TITLE
chore(worker-pools): update 25H2 alpha and AMD SKUs and remove 24H2 AMD

### DIFF
--- a/grants.d/grants.yml
+++ b/grants.d/grants.yml
@@ -259,7 +259,6 @@
     - generic-worker:os-group:gecko-t/win11-64-2009/Administrators
     - generic-worker:os-group:gecko-t/win11-64-24h2/Administrators
     - generic-worker:os-group:gecko-t/win11-64-24h2-privileged/Administrators
-    - generic-worker:os-group:gecko-t/win11-64-24h2-amd/Administrators
     - generic-worker:os-group:gecko-t/win11-64-25h2-amd/Administrators
     - generic-worker:os-group:gecko-t/win11-64-2009-alpha/Administrators
     - generic-worker:os-group:gecko-t/win11-64-24h2-alpha/Administrators
@@ -281,7 +280,6 @@
     - generic-worker:run-as-administrator:gecko-t/win11-64-25h2-privileged
     - generic-worker:run-as-administrator:gecko-t/win11-64-2009
     - generic-worker:run-as-administrator:gecko-t/win11-64-24h2
-    - generic-worker:run-as-administrator:gecko-t/win11-64-24h2-amd
     - generic-worker:run-as-administrator:gecko-t/win11-64-24h2-source
     - generic-worker:run-as-administrator:gecko-t/win11-64-25h2-amd
     - generic-worker:run-as-administrator:releng-hardware/win11-64*

--- a/worker-images.yml
+++ b/worker-images.yml
@@ -189,9 +189,3 @@ ronin_t_windows11_64_2009:
     resource_group: rg-packer-worker-images
     deployment_id: "96de7f5"
     name: win11_64_2009
-win116424h2alpha:
-  azure2:
-    version: 1.0.0
-    resource_group: rg-packer-worker-images
-    deployment_id: alpha
-    name: win116424h2alpha

--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -2845,56 +2845,6 @@ pools:
                 central-india: 1
                 default: 0.5
             default: 1
-  - pool_id: 'gecko-t/win11-64-24h2-amd'
-    description: ''
-    owner: relops-azure-provisioning@mozilla.com
-    email_on_error: true
-    provider_id: azure2
-    config:
-      image: win116424h2alpha
-      image_resource_group: rg-packer-through-cib
-      implementation: generic-worker/windows
-      locations: [uk-south, central-india]
-      maxCapacity: 100
-      armDeployment:
-        templateSpecId: /subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template-v6-nvme/versions/1.0
-      worker-config:
-        genericWorker:
-          config:
-            workerType: 'win11-64-24h2-amd'
-            provisionerId: gecko-t
-            cachesDir: C:\caches
-            downloadsDir: C:\downloads
-            tasksDir: C:\
-      tags:
-        sourceScript: provisioners/windows/azure/azure-bootstrap.ps1
-        sourceBranch: windows
-        sourceRepository: ronin_puppet
-        sourceOrganisation: mozilla-platform-ops
-      spot: true
-      vmSizes:
-        - vmSize: Standard_E8ads_v6
-          launchConfig:
-            osProfile:
-              windowsConfiguration:
-                timeZone: UTC
-                enableAutomaticUpdates: false
-            storageProfile:
-              osDisk:
-                osType: Windows
-                caching: ReadOnly
-                createOption: FromImage
-                diffDiskSettings:
-                  option: Local
-                  placement: NvmeDisk
-            hardwareProfile:
-              vmSize: Standard_E8ads_v6
-            diagnosticsProfile:
-              bootDiagnostics:
-                enabled: false
-      worker-manager-config:
-        capacityPerInstance: 1
-        initialWeight: 1
   - pool_id: '{pool-group}/win11-64-25h2-{suffix}'
     description: ''
     owner: relops-azure-provisioning@mozilla.com
@@ -3006,6 +2956,8 @@ pools:
             templateSpecId: /subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template-dedicated-host/versions/1.0
             parameters:
               priority: Regular
+          alpha:
+            templateSpecId: /subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template-v6-nvme/versions/1.0
           default:
             templateSpecId: /subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template/versions/1.0
       worker-config:
@@ -3032,7 +2984,7 @@ pools:
             by-suffix:
               source-alpha: Standard_E8ads_v5
               .*large.*: Standard_E8ads_v5
-              alpha: Standard_F8s_v2
+              alpha: Standard_D8alds_v6
               .*gpu.*: Standard_NV12ads_A10_v5
               default: Standard_F8s_v2
           launchConfig:
@@ -3053,7 +3005,7 @@ pools:
                 by-suffix:
                   source-alpha: Standard_E8ads_v5
                   .*large.*: Standard_E8ads_v5
-                  alpha: Standard_F8s_v2
+                  alpha: Standard_D8alds_v6
                   .*gpu.*: Standard_NV12ads_A10_v5
                   default: Standard_F8s_v2
             diagnosticsProfile:
@@ -3064,6 +3016,20 @@ pools:
         initialWeight:
           by-vmSize:
             Standard_F8s_v2:
+              by-location:
+                west-us-3: 1
+                north-central-us: 0.95
+                central-india: 0.95
+                west-us: 0.8
+                south-india: 0.8
+                central-us: 0.5
+                east-us: 0.5
+                north-europe: 0.4
+                canada-central: 0.3
+                west-us-2: 0.3
+                east-us-2: 0.1
+                default: 0.2
+            Standard_D8alds_v6:
               by-location:
                 west-us-3: 1
                 north-central-us: 0.95
@@ -3116,7 +3082,7 @@ pools:
         sourceOrganisation: mozilla-platform-ops
       spot: true
       vmSizes:
-        - vmSize: Standard_E8ads_v6
+        - vmSize: Standard_D8alds_v6
           launchConfig:
             osProfile:
               windowsConfiguration:
@@ -3131,7 +3097,7 @@ pools:
                   option: Local
                   placement: NvmeDisk
             hardwareProfile:
-              vmSize: Standard_E8ads_v6
+              vmSize: Standard_D8alds_v6
             diagnosticsProfile:
               bootDiagnostics:
                 enabled: false


### PR DESCRIPTION
## Summary
- Move exact `win11-64-25h2-alpha` pools to `Standard_D8alds_v6` using the v6 NVMe ARM template.
- Move standalone `gecko-t/win11-64-25h2-amd` from `Standard_E8ads_v6` to `Standard_D8alds_v6`.
- Keep specialized 25H2 alpha variants on their existing SKUs, including source, large, GPU, and WebGPU pools.
- Keep `ronin_t_windows11_64_24h2_alpha` as-is for 24H2 alpha pool testing while removing the retired `gecko-t/win11-64-24h2-amd` pool, grants, and unused `win116424h2alpha` image entry.

## Validation
- `uv run pytest tests/ciadmin/test_generate_worker_pools.py -q`
- `GITHUB_TOKEN="$(gh auth token)" uv run tc-admin check --environment=firefoxci -- -q`
- Azure SKU API shows `Standard_D8alds_v6` is unrestricted, `LowPriorityCapable=True`, and supports `NvmeDisk` ephemeral OS placement in `westus3`, `eastus`, `eastus2`, `westus2`, `westus`, `centralindia`, and `uksouth`.