### PR TITLE
Bug 2042529 - Restore Windows 24H2 AArch64 builder pools

### DIFF
--- a/worker-images.yml
+++ b/worker-images.yml
@@ -141,6 +141,24 @@ trusted_win11_a64_25h2_builder:
     resource_group: rg-packer-worker-images
     deployment_id: "757b34d"
     name: trusted_win11_a64_25h2_builder
+ronin_b1_windows11_a64_24h2_builder_alpha:
+  azure2:
+    version: 1.0.0
+    resource_group: rg-packer-worker-images
+    deployment_id: alpha
+    name: win11_a64_24h2_builder_alpha
+ronin_b1_windows11_a64_24h2_builder:
+  azure2:
+    version: 1.3.3
+    resource_group: rg-packer-worker-images
+    deployment_id: "71b0588"
+    name: win11_a64_24h2_builder
+ronin_b3_windows11_a64_24h2_builder:
+  azure_trusted:
+    version: 1.3.4
+    resource_group: rg-packer-worker-images
+    deployment_id: "757b34d"
+    name: trusted_win11_a64_24h2_builder
 win11a6425h2tester:
   azure2:
     version: 1.0.4

--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -2413,6 +2413,102 @@ pools:
                 default: 0.5
             default: 1
   # Windows 11
+  - pool_id: '{pool-group}/win11-a64-24h2-builder-{suffix}'
+    description: ''
+    owner: relops-azure-provisioning@mozilla.com
+    email_on_error: true
+    attributes:
+      suffix: ''
+      level: 1
+      implementation: generic-worker/windows
+    variants:
+      - pool-group: gecko-1
+      - pool-group: gecko-3
+        level: 3
+      - pool-group: gecko-1
+        suffix: alpha
+        implementation: generic-worker/windows
+      - pool-group: enterprise-1
+      - pool-group: enterprise-3
+        level: 3
+      - pool-group: mozillavpn-1
+      - pool-group: mozillavpn-3
+        level: 3
+      - pool-group: nss-1
+        suffix: alpha
+        implementation: generic-worker/windows
+      - pool-group: nss-1
+      - pool-group: nss-3
+        level: 3
+    provider_id:
+      by-level:
+        1: azure2
+        3: azure_trusted
+    config:
+      image: 'ronin_b{level}_windows11_a64_24h2_builder_{suffix}'
+      implementation: '{implementation}'
+      worker-purpose:
+        by-pool-group:
+          mozillavpn-1: vpn-1
+          mozillavpn-3: vpn-3
+          default: null  # defaults to pool-group
+      locations: [central-india, east-us-2, north-central-us, central-us]
+      maxCapacity:
+        by-pool-group:
+          nss-.*: 25
+          gecko.*: 250
+          default: 10
+      worker-config:
+        genericWorker:
+          config:
+            workerType: win11-a64-24h2-builder-{suffix}
+            provisionerId: '{pool-group}'
+            cachesDir: D:\caches
+            downloadsDir: D:\downloads
+            tasksDir: D:\
+      tags:
+        sourceScript: provisioners/windows/azure/azure-bootstrap.ps1
+        sourceBranch: windows
+        sourceRepository: ronin_puppet
+        sourceOrganisation: mozilla-platform-ops
+      spot: true
+      armDeployment:
+        by-level:
+          1:
+            templateSpecId: /subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template/versions/1.0
+          3:
+            templateSpecId: /subscriptions/a30e97ab-734a-4f3b-a0e4-c51c0bff0701/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template/versions/1.0
+      vmSizes:
+        - vmSize: Standard_D16pds_v5
+          launchConfig:
+            osProfile:
+              windowsConfiguration:
+                timeZone: UTC
+                enableAutomaticUpdates: false
+            storageProfile:
+              osDisk:
+                osType: Windows
+                caching: ReadOnly
+                createOption: FromImage
+                diffDiskSettings:
+                  option: Local
+            hardwareProfile:
+              vmSize: Standard_D16pds_v5
+            diagnosticsProfile:
+              bootDiagnostics:
+                enabled: false
+      worker-manager-config:
+        capacityPerInstance: 1
+        initialWeight:
+          by-vmSize:
+            Standard_D16pds_v5:
+              by-location:
+                central-india: 1
+                east-us-2: 0.9
+                north-central-us: 0.9
+                central-us: 0.8
+                default: 0.5
+            default: 1
   - pool_id: '{pool-group}/win11-a64-25h2-builder-{suffix}'
     description: ''
     owner: relops-azure-provisioning@mozilla.com


### PR DESCRIPTION
Partial revert of #1017.

Restores only the Windows 11 24H2 AArch64 builder image entries and builder worker-pool template. The 24H2 AArch64 tester pools remain removed.

Validation:
- uv run pytest tests -vv
- tc-admin worker-pool checks passed for firefoxci
- tc-admin worker-pool checks passed for staging
