### PR TITLE
Remove two unused static clients

### DIFF
--- a/clients.yml
+++ b/clients.yml
@@ -1365,29 +1365,6 @@ project/relsre/devicepool:
   scopes:
     - queue:claimed-count:*
     - queue:pending-count:*
-project/taskcluster/legacy-login:
-  description: ''
-  scopes:
-    - assume:github-org-admin:*
-    - assume:github-team:*
-    - assume:login-identity:*
-    - assume:mozilla-group:*
-    - assume:mozillians-group:*
-    - auth:azure-table:read-write:firefoxcitc/AccessTokenTable
-    - auth:azure-table:read-write:firefoxcitc/AuthorizationCodesTable
-    - auth:azure-table:read-write:firefoxcitc/GithubAccessTokenTable
-    - auth:create-client:github/*
-    - auth:create-client:mozilla-auth0/*
-    - auth:delete-client:github/*
-    - auth:delete-client:mozilla-auth0/*
-    - auth:disable-client:github/*
-    - auth:disable-client:mozilla-auth0/*
-    - auth:enable-client:github/*
-    - auth:enable-client:mozilla-auth0/*
-    - auth:reset-access-token:github/*
-    - auth:reset-access-token:mozilla-auth0/*
-    - auth:update-client:github/*
-    - auth:update-client:mozilla-auth0/*
 project/taskcluster/smoketest:
   description: Run smoketests on new Taskcluster deployments
   scopes:

--- a/clients.yml
+++ b/clients.yml
@@ -304,17 +304,6 @@ project/enterprise/enterprise-console-backend/dev/artifact-access:
     enterprise artifacts.
   scopes:
     - queue:get-artifact:project/enterprise/*
-project/packet/docker-worker:
-  description: ''
-  scopes:
-    - auth:sentry:docker-worker
-    - auth:statsum:docker-worker
-    - queue:claim-task:terraform-packet/*
-    - queue:claim-work:terraform-packet/*
-    - queue:worker-id:packet-*
-    - secrets:get:project/taskcluster/docker-worker/certificate-key
-    - secrets:get:worker-pool:terraform-packet/*
-    - secrets:get:worker-type:terraform-packet/*
 project/releng/fxci-config/apply:
   description: Used to run `tc-admin apply` in mozilla-releng/fxci-config.
   scopes:


### PR DESCRIPTION
Packet I was able to trace back to the last user being removed in https://bugzilla.mozilla.org/show_bug.cgi?id=1635877, the other one predates that and I didn't feel like going digging past the existence of this repo (https://bugzilla.mozilla.org/show_bug.cgi?id=1632009 is what added it here).

Both have their last used date > 5y, so I think it's safe to assume they can be removed.