### PR TITLE
Bug 2044114 - Create git-push hook for mozilla/firefox-dev

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -589,6 +589,7 @@ firefox-dev:
       level: 1
   features:
     gecko-roles: true
+    git-push: true
     github-taskgraph: true
     github-pull-request:
       policy: collaborators


### PR DESCRIPTION
This will allow us to trigger CI via build-decision on this repo.