### PR TITLE
feat(worker-pools): add nss pool-groups to aarch64 builder and image pools

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -555,6 +555,9 @@ pools:
       - pool-group: enterprise-1
       - pool-group: enterprise-3
         chain-of-trust: trusted
+      - pool-group: nss-1
+      - pool-group: nss-3
+        chain-of-trust: trusted
     email_on_error: true
     provider_id:
       by-chain-of-trust:
@@ -1164,6 +1167,9 @@ pools:
         chain-of-trust: trusted
       - pool-group: enterprise-1
       - pool-group: enterprise-3
+        chain-of-trust: trusted
+      - pool-group: nss-1
+      - pool-group: nss-3
         chain-of-trust: trusted
     email_on_error: false
     provider_id:


### PR DESCRIPTION
I'm a bit out of by depth here, but I'm trying to get NSS tests running on linux aarch64 workers in [D306011](https://phabricator.services.mozilla.com/D306011) and Claude suggested this change. Let me know if I'm off base.