### PR TITLE
bug 2037926 - grant gecko-1-lando-dev scope to staging-xpi-manifest

### DIFF
--- a/grants.d/xpi.yml
+++ b/grants.d/xpi.yml
@@ -12,6 +12,8 @@
     - queue:create-task:highest:xpi-{level}/*
     - queue:create-task:highest:scriptworker-k8s/{trust_domain}-{level}-*
     - queue:create-task:highest:scriptworker-k8s/{trust_domain}-t-*
+    # Bug 2037926: dev lando worker used by staging-xpi-manifest for staging e2e test
+    - queue:create-task:highest:scriptworker-k8s/xpi-1-lando-dev
     - queue:route:index.{trust_domain}.v2.xpi-manifest.*
     - queue:route:index.xpi.cache.level-{level}.*
   to:


### PR DESCRIPTION
## Summary

- Grants `queue:create-task:highest:scriptworker-k8s/gecko-1-lando-dev` to `staging-xpi-manifest` release-promotion actions
- Required for the staging e2e test: staging-xpi-manifest is temporarily configured to use the dev landoscript workers (`gecko-1-lando-dev`) instead of `xpi-1-lando`, but the decision task lacked the scope to create tasks on that worker pool

## Merge order

Part of the [Bug 2037926](https://bugzilla.mozilla.org/show_bug.cgi?id=2037926) staging e2e test sequence. Apply staging with `/taskcluster apply-staging` then re-trigger the staging-xpi-manifest release promotion.

Revert `staging-xpi-manifest` config change and this grant once staging verification is complete.