### PR TITLE
bug 2037926 - grant file-specific version_bump scopes (production)

### DIFF
--- a/grants.d/grants.yml
+++ b/grants.d/grants.yml
@@ -2332,6 +2332,10 @@
 
 - grant:
     - project:releng:lando:action:version_bump
+    - project:releng:lando:action:version_bump:file:browser/config/version.txt
+    - project:releng:lando:action:version_bump:file:browser/config/version_display.txt
+    - project:releng:lando:action:version_bump:file:config/milestone.txt
+    - project:releng:lando:action:version_bump:file:mobile/android/version.txt
     - project:releng:lando:repo:{lando_repo}
   to:
     - project:

--- a/grants.d/xpi.yml
+++ b/grants.d/xpi.yml
@@ -96,9 +96,10 @@
         - team_moco
         - team_mozillaonline
 
-# Bug 2025695: lando scopes for newtab XPI version bump
 - grant:
     - project:releng:lando:action:version_bump
+    - project:releng:lando:action:version_bump:file:browser/extensions/newtab/manifest.json
+    - project:releng:lando:action:version_bump:file:browser/extensions/webcompat/manifest.json
     - project:releng:lando:repo:firefox-main
   to:
     - project:


### PR DESCRIPTION
## Coverage of all `version_bump` grants

| Grant | Recipient | Status |
|-------|-----------|--------|
| [`grants.d/xpi.yml#L99-L108`](https://github.com/mozilla-releng/fxci-config/blob/11018d486450a0a0b1dd69906f3e583676f90390/grants.d/xpi.yml#L99-L108) | `xpi-manifest` → `firefox-main` | ✅ this PR |
| [`grants.d/xpi.yml#L110-L118`](https://github.com/mozilla-releng/fxci-config/blob/a8057695bd44b6ca9f99529bafccf0bb2c994a5c/grants.d/xpi.yml#L110-L118) | `staging-xpi-manifest` → `staging-firefox-main` | ✅ [#1012](https://github.com/mozilla-releng/fxci-config/pull/1012) merged |
| [`grants.d/grants.yml#L2334-L2343`](https://github.com/mozilla-releng/fxci-config/blob/11018d486450a0a0b1dd69906f3e583676f90390/grants.d/grants.yml#L2334-L2343) | Firefox release (`mozilla-beta/release/esr*`) | ✅ this PR |
| [`grants.d/grants.yml#L2276`](https://github.com/mozilla-releng/fxci-config/blob/a8057695bd44b6ca9f99529bafccf0bb2c994a5c/grants.d/grants.yml#L2276) | `try` + `firefox` PRs | ✅ `lando:action:*` wildcard covers `version_bump:file:*` |

## Merge order

1. [fxci-config staging #1012](https://github.com/mozilla-releng/fxci-config/pull/1012) — ✅ merged
2. [scriptworker-scripts #1448](https://github.com/mozilla-releng/scriptworker-scripts/pull/1448) — ✅ staged and verified, awaiting merge to `master`
3. This PR — merge **before** mozilla-taskgraph
4. [mozilla-taskgraph #215](https://github.com/mozilla-releng/mozilla-taskgraph/pull/215) — merge + publish
5. xpi-manifest — update mozilla-taskgraph pin
6. firefox gecko_taskgraph — Phabricator + uplift
7. fxci-config cleanup (separate PR) — remove old general `version_bump` grants
8. scriptworker-scripts cleanup (separate PR) — remove transition fallback from `validate_scopes`

[Bug 2037926](https://bugzilla.mozilla.org/show_bug.cgi?id=2037926)
