### PR TITLE
Increase win11-64-25h2-large capacity

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -2953,6 +2953,7 @@ pools:
               alpha: 500
               gpu: 600
               gpu-perf-experiment: 12
+              large: 150
               default: 100
           enterprise-t: 200
           default: 5


### PR DESCRIPTION
## Summary
- Raise `gecko-t/win11-64-25h2-large` maxCapacity from the inherited default of 100 to 150.
- Leave `gecko-t/win11-64-25h2-large-alpha` at 100.

## Validation
- `uv run tc-admin generate --environment=firefoxci --resources=worker_pools --grep '^WorkerPool=gecko-t/win11-64-25h2-large$' --json`\n- `uv run tc-admin generate --environment=firefoxci --resources=worker_pools --grep '^WorkerPool=gecko-t/win11-64-25h2-large-alpha$' --json`\n- `uv run tc-admin check --environment=firefoxci --resources=worker_pools -- -k worker_pool`