### PR TITLE
feat: switch reps pull request policy to public

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -772,7 +772,7 @@ reps:
   features:
     github-taskgraph: true
     github-pull-request:
-      policy: public_restricted
+      policy: public
     taskgraph-actions: true
     trust-domain-scopes: true
 


### PR DESCRIPTION
AFAICT this repository doesn't run any tasks that require secrets, so we can enable public pull requests.

(The template that this tool uses to create other configurations does, but that doesn't matter here...)