### PR TITLE
fix: grant mozilla-fennec-geoloc-api secret to enterprise

### DIFF
--- a/grants.d/enterprise.yml
+++ b/grants.d/enterprise.yml
@@ -51,6 +51,7 @@
     - secrets:get:project/releng/gecko/build/level-{level}/gls-gapi.data
     - secrets:get:project/releng/gecko/build/level-{level}/sb-gapi.data
     - secrets:get:project/releng/gecko/build/level-{level}/mozilla-desktop-geoloc-api.key
+    - secrets:get:project/releng/gecko/build/level-{level}/mozilla-fennec-geoloc-api.key
   to:
     - project:
         feature: gecko-roles


### PR DESCRIPTION
Unblocks https://github.com/mozilla/enterprise-firefox/pull/891

Bug: 2039183