### PR TITLE
Lower scaling ratio for win11 25H2 pools

### DIFF
--- a/src/ciadmin/generate/worker_pools.py
+++ b/src/ciadmin/generate/worker_pools.py
@@ -781,6 +781,7 @@ def generate_pool_variants(worker_pools, environment):
             "maxCapacity",
             "minCapacity",
             "regions",
+            "scalingRatio",
             "security",
             "tags.sourceBranch",
             "vmSizes.launchConfig.hardwareProfile.vmSize",

--- a/tests/ciadmin/test_generate_worker_pools.py
+++ b/tests/ciadmin/test_generate_worker_pools.py
@@ -323,6 +323,49 @@ def assert_guest_accelerators(pool):
     }
 
 
+def test_generate_pool_variants_resolves_scaling_ratio(environment):
+    pool = WorkerPool(
+        pool_id="{pool-group}/win11-64-25h2-{suffix}",
+        description="",
+        owner="user@example.com",
+        provider_id="azure",
+        email_on_error=False,
+        attributes={"suffix": ""},
+        variants=[
+            {"pool-group": "gecko-t"},
+            {"pool-group": "gecko-t", "suffix": "gpu"},
+            {"pool-group": "gecko-t", "suffix": "large"},
+            {"pool-group": "enterprise-t"},
+        ],
+        config={
+            "scalingRatio": {
+                "by-pool-group": {
+                    "gecko-t": {
+                        "by-suffix": {
+                            "": 0.5,
+                            "gpu": 0.5,
+                            "default": 1,
+                        },
+                    },
+                    "default": 1,
+                },
+            },
+        },
+    )
+
+    ratios = {
+        variant.pool_id: variant.config["scalingRatio"]
+        for variant in generate_pool_variants([pool], environment.name)
+    }
+
+    assert ratios == {
+        "gecko-t/win11-64-25h2": 0.5,
+        "gecko-t/win11-64-25h2-gpu": 0.5,
+        "gecko-t/win11-64-25h2-large": 1,
+        "enterprise-t/win11-64-25h2": 1,
+    }
+
+
 @pytest.mark.parametrize(
     "provider,extra_pool_config,extra_cloud_config",
     (

--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -2957,6 +2957,14 @@ pools:
               default: 100
           enterprise-t: 200
           default: 5
+      scalingRatio:
+        by-pool-group:
+          gecko-t:
+            by-suffix:
+              '': 0.5
+              gpu: 0.5
+              default: 1
+          default: 1
       armDeployment:
         by-suffix:
           gpu-perf-experiment:


### PR DESCRIPTION
Summary:
- Set scalingRatio to 0.5 for gecko-t/win11-64-25h2 and gecko-t/win11-64-25h2-gpu.
- Add scalingRatio to keyed-by evaluation so the shared 25H2 template can target only those variants.
- Add a focused generator test confirming the base and GPU pools resolve to 0.5 while neighboring variants remain at 1.

Context:
- Temporary mitigation for worker-manager burst over-provisioning while https://github.com/taskcluster/taskcluster/issues/8783 is investigated.

Verification:
- uv run pytest tests/ciadmin/test_generate_worker_pools.py
- uv run tc-admin generate --environment=firefoxci --resources worker_pools --json --grep "gecko\-t/win11\-64\-25h2"
- uv run tc-admin diff --environment=firefoxci --resources worker_pools --grep "WorkerPool=gecko\-t/win11\-64\-25h2(\-gpu)?$" -U 3

The targeted tc-admin diff showed only these live changes:
- gecko-t/win11-64-25h2: scalingRatio 1 -> 0.5
- gecko-t/win11-64-25h2-gpu: scalingRatio 1 -> 0.5