### PR TITLE
fix: use windows generic-worker config for fuzzing pools

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -3583,7 +3583,7 @@ pools:
     provider_id: azure2
     config:
       image: fuzzing-gw-win2022
-      implementation: generic-worker/worker-runner-windows
+      implementation: generic-worker/windows
       worker-purpose: proj-fuzzing
       locations: [central-us, east-us]
       maxCapacity: 10
@@ -3617,7 +3617,7 @@ pools:
         by-kind:
           gpu: fuzzing-gw-win2022-gpu
           ngpu: fuzzing-gw-win2022
-      implementation: generic-worker/worker-runner-windows
+      implementation: generic-worker/windows
       worker-purpose: proj-fuzzing
       locations:
         by-kind:
@@ -3683,7 +3683,7 @@ pools:
     provider_id: azure2
     config:
       image: fuzzing-gw-win2022-gpu
-      implementation: generic-worker/worker-runner-windows
+      implementation: generic-worker/windows
       worker-purpose: proj-fuzzing
       locations: [east-us, east-us-2, south-central-us, west-us-2]
       maxCapacity: 20


### PR DESCRIPTION
## Summary
- switch the Azure fuzzing Windows pools to `generic-worker/windows`
- avoid emitting `runTasksAsCurrentUser`, which the migrated fuzzing images reject at startup

Follows the merged fuzzing work in #899, #1042, and #1048. The smoke tasks now get past pool creation/ARM provisioning but fail when generic-worker loads config.

## Verification
- targeted generation check: affected pools no longer include `runTasksAsCurrentUser` and still use ARM launch configs
- `uv run pytest tests/ciadmin/test_generate_worker_pools.py`
- `GITHUB_TOKEN=$(gh auth token) uv run tc-admin check --environment firefoxci`