### PR TITLE
fix: use fuzzing Windows generic-worker signing key

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -78,7 +78,7 @@ worker-defaults:
         genericWorker:
           config:
             livelogExecutable: C:\generic-worker\livelog.exe
-            ed25519SigningKeyLocation: C:\generic-worker\ed25519-private.key
+            ed25519SigningKeyLocation: C:\generic-worker\generic-worker-ed25519-signing-key.key
             idleTimeoutSecs: 15
             shutdownMachineOnIdle: true
             shutdownMachineOnInternalError: true


### PR DESCRIPTION
## Summary
- Point the fuzzing Windows generic-worker profile at the key generated by the migrated Community TC Windows images.
- A live FXCI fuzzing VM had `ed25519-private.key` missing, `generic-worker-ed25519-signing-key.key` present, and the Generic Worker service stopped with exit code 82.

## Context
Follows the merged fuzzing migration work in #899, #1042, #1048, #1049, and #1051.

## Testing
- `git diff --check`
- commit hooks: yamllint/pre-commit
