### PR TITLE
fix: bump fuzzing Windows images to Taskcluster 100

### DIFF
--- a/worker-images.yml
+++ b/worker-images.yml
@@ -214,10 +214,10 @@ fuzzing-gw-win2022-gpu:
     resource_group: rg-packer-worker-images
     deployment_id: fuzzing
     sbom: false
-    east-us: imageset-fcxybmrwdcsmxjijwamv-eastus
-    east-us-2: imageset-ofghwxvlubvnimhurgqa-eastus2
-    south-central-us: imageset-hhgwofqoyyhwaxoucnli-southcentralus
-    west-us-2: imageset-owexteqnyghtbsfeuppb-westus2
+    east-us: imageset-ajdnmqrgviixcxbrlwlm-eastus
+    east-us-2: imageset-kqjastlpfcktfmbknacc-eastus2
+    south-central-us: imageset-wklenlbxaoeghdemjdyk-southcentralus
+    west-us-2: imageset-cnnahgrkshgsftrapiac-westus2
 
 fuzzing-gw-win2022:
   azure2:
@@ -225,5 +225,5 @@ fuzzing-gw-win2022:
     resource_group: rg-packer-worker-images
     deployment_id: fuzzing
     sbom: false
-    central-us: imageset-pytrrvjottfuqbemodpn-centralus
-    east-us: imageset-qqkmmgddstxfhvbsdprj-eastus
+    central-us: imageset-vjyypxaraoyqmuewlwjn-centralus
+    east-us: imageset-lhtxjttusjeblyqqytss-eastus


### PR DESCRIPTION
## Summary
- update fuzzing Win2022 and Win2022 GPU managed images to Taskcluster/generic-worker 100.0.1
- match Community TC's current fuzzing Windows baseline and pick up the Windows LoadUserProfile retry fixes

## Build provenance
- worker-images #806
- non-GPU images: https://github.com/mozilla-platform-ops/worker-images/actions/runs/27555837122
- GPU images: https://github.com/mozilla-platform-ops/worker-images/actions/runs/27981818918
- all referenced Azure images are tagged taskcluster_version=100.0.1

## Related
Follow-up to fxci-config #1042, #1048, #1049, #1051, and #1052.