### PR TITLE
feat(gcp): update Ubuntu 24.04 images to 2026-06-23 builds

### DIFF
--- a/worker-images.yml
+++ b/worker-images.yml
@@ -61,7 +61,7 @@ relsre-gw-fxci-gcp-2404-amd64-gui-alpha:
 ubuntu-2404-wayland:
   ## Bug 1902716
   ## 2404 ubuntu image with wayland
-  fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-2404-amd64-gui-googlecompute-2026-05-04
+  fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-2404-amd64-gui-googlecompute-2026-06-23
 
 relsre-gw-fxci-gcp-2404-amd64-alpha:
   ## alpha pool that relsre can use to rebuild and test 2404 ubuntu images
@@ -74,8 +74,8 @@ ubuntu-2404-headless-alpha:
 
 ubuntu-2404-headless:
   ## Headless Image for Ubuntu 24.04
-  fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-2404-amd64-headless-googlecompute-2026-05-04
-  fxci-level3-gcp: projects/fxci-production-level3-workers/global/images/gw-fxci-gcp-l3-2404-amd64-headless-googlecompute-2026-05-04
+  fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-2404-amd64-headless-googlecompute-2026-06-23
+  fxci-level3-gcp: projects/fxci-production-level3-workers/global/images/gw-fxci-gcp-l3-2404-amd64-headless-googlecompute-2026-06-23
 
 ubuntu-2404-headless-alpha-tc:
   ## alpha pool that tc can use to rebuild and test 2404 headless ubuntu images
@@ -87,8 +87,8 @@ ubuntu-2404-arm64-headless-alpha:
   fxci-level3-gcp: projects/fxci-production-level3-workers/global/images/gw-fxci-gcp-l3-2404-arm64-headless-googlecompute-alpha
 ubuntu-2404-arm64-headless:
   ## Headless Image for Ubuntu 24.04 arm64
-  fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-2404-arm64-headless-googlecompute-2026-05-04
-  fxci-level3-gcp: projects/fxci-production-level3-workers/global/images/gw-fxci-gcp-l3-2404-arm64-headless-googlecompute-2026-05-04
+  fxci-level1-gcp: projects/taskcluster-imaging/global/images/gw-fxci-gcp-l1-2404-arm64-headless-googlecompute-2026-06-23
+  fxci-level3-gcp: projects/fxci-production-level3-workers/global/images/gw-fxci-gcp-l3-2404-arm64-headless-googlecompute-2026-06-23
 
 # Windows Server 2022
 ronin_b1_windows2022_64_2009_alpha:

--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -739,7 +739,7 @@ pools:
       instance_types:
         - minCpuPlatform: Intel Cascadelake
           disks:
-            - *persistent-disk-60gb
+            - *persistent-disk-75gb
           machine_type: n2-highmem-32
   - pool_id: '{pool-group}/b-linux-large-gcp-d2g-1tb'
     description: Big workers with big disks - intended for Firefox Translations only


### PR DESCRIPTION
## Summary

- Updates the Ubuntu 24.04 GCP worker image references to the `2026-06-23` builds for `ubuntu-2404-headless`, `ubuntu-2404-arm64-headless` (both level-1 and level-3), and `ubuntu-2404-wayland` (level-1).
- Bumps generic-worker to **100.4.0** on the level-1 images and **100.3.0** on the level-3 trusted images, and picks up Wayland input tools / PyAutoGUI deps on the GUI image plus a GCP NVIDIA toolkit provisioning fix.
- These are the first Ubuntu image references to move since the `2026-05-04` builds (#968); the intermediate `2026-06-10` build was never rolled into production.

## Build provenance

Built from [mozilla-platform-ops/worker-images run 28037696082](https://github.com/mozilla-platform-ops/worker-images/actions/runs/28037696082) at commit `875beb2`. [Compare against the 2026-05-04 build](https://github.com/mozilla-platform-ops/worker-images/compare/4a152e1f...875beb2).
