### PR TITLE
Migrate proj-taskcluster from community-tc

### DIFF
--- a/clients.yml
+++ b/clients.yml
@@ -1349,10 +1349,27 @@ project/relsre/devicepool:
   scopes:
     - queue:claimed-count:*
     - queue:pending-count:*
+
 project/taskcluster/smoketest:
-  description: Run smoketests on new Taskcluster deployments
+  description: For running smoke tests against firefox-ci services (typically when deploying updated serivces)
   scopes:
     - assume:project:taskcluster:smoketests
+project/taskcluster/generic-worker/ci-macos:
+  description: Client for all workers in static workerpool proj-taskcluster/gw-ci-macos.
+  scopes:
+    - assume:worker-pool:proj-taskcluster/gw-ci-macos
+    - assume:worker-id:proj-taskcluster/*
+project/taskcluster/generic-worker/taskcluster-ci:
+  description: |
+    A client used by generic-worker CI tests.
+  scopes:
+    - assume:project:taskcluster:generic-worker-tester
+project/taskcluster/testing/client-libraries:
+  description: |
+    This client is used to test the client libraries in Taskcluster CI.
+  scopes:
+    - "object:upload:taskcluster:taskcluster/test/*"
+    - "object:download:taskcluster/test/*"
 project/taskcluster/audit-reports:
   description: Used for auditing worker versions across pools.
   scopes:
@@ -1360,6 +1377,7 @@ project/taskcluster/audit-reports:
     - queue:scheduler-id:smoketest
     - queue:seal-task-group:smoketest/*
     - queue:get-artifact:public/*
+
 project/wpt/wptsync:
   description: Created in Bug 1596469 - Secret handed to :jgraham
   scopes:

--- a/externally-managed.yml
+++ b/externally-managed.yml
@@ -19,3 +19,9 @@ fuzzing:
   - "Hook=project-fuzzing/.*"
   - "Role=hook-id:project-fuzzing/.*"
   - "Secret=project/fuzzing/.*"
+
+taskcluster:
+  # smoketests create these resources, and also cleans them up, so leave
+  # them alone here...
+  - "Client=project/taskcluster/smoketest/.*"
+  - "Role=project:taskcluster:smoketest:.*"

--- a/grants.d/taskcluster.yml
+++ b/grants.d/taskcluster.yml
@@ -1,0 +1,211 @@
+# Taskcluster project grants
+
+- grant:
+    - notify:manage-denylist
+    # This is the taskcluster channel
+    - queue:route:notify.matrix-room.!whDRjjSmICCgrhFHsQ:mozilla.org.*
+  to:
+    - roles:
+        - project-admin:taskcluster
+
+- grant:
+    - queue:create-task:highest:proj-taskcluster/ci
+    # For replacing the docker-worker pool (proj-taskcluster/ci) for d2g work
+    - queue:create-task:highest:proj-taskcluster/gw-ubuntu-24-04
+    # The account and secret for the Azure testing storage account.
+    # This is secret but ok for use by PRs.
+    - secrets:get:project/taskcluster/testing/azure
+    # This is the taskcluster channel
+    - queue:route:notify.matrix-room.!whDRjjSmICCgrhFHsQ:mozilla.org.*
+  to:
+    - roles:
+        - repo:github.com/taskcluster/*
+
+- grant:
+    - queue:create-task:highest:proj-taskcluster/ci
+  to:
+    - roles:
+        - repo:github.com/mozilla/hawk:*
+
+- grant:
+    - secrets:get:project/taskcluster/testing/client-libraries
+    - secrets:get:project/taskcluster/testing/taskcluster-*
+    - docker-worker:cache:taskcluster-*
+  to:
+    - roles:
+        - repo:github.com/taskcluster/taskcluster:*
+
+- grant:
+    - queue:create-task:highest:proj-taskcluster/release
+    - secrets:get:project/taskcluster/release
+  to:
+    - roles:
+        - repo:github.com/taskcluster/taskcluster:tag:v*
+
+- grant:
+    - queue:create-task:highest:proj-taskcluster/release
+    - secrets:get:project/taskcluster/staging-release
+  to:
+    - roles:
+    # both pre- and post-bug-1635455
+        - repo:github.com/taskcluster/taskcluster:branch:staging-release/*
+        - repo:github.com/taskcluster/staging-releases:*
+
+- grant:
+    # pushes to main and releases can notify on failure
+    - queue:route:notify.email.taskcluster-internal@mozilla.com.*
+    - queue:route:notify.email.taskcluster-notifications@mozilla.com.*
+    - queue:route:notify.irc-channel.#taskcluster-bots.*
+  to:
+    - roles:
+        - repo:github.com/taskcluster/taskcluster:branch:main
+        - repo:github.com/taskcluster/taskcluster:tag:v*
+
+- grant:
+    - queue:create-task:highest:proj-taskcluster/ci
+  to:
+    - roles:
+        - repo:github.com/json-e/json-e:*
+
+- grant:
+    # pushes to json-e main can read secrets for deploying the site
+    - secrets:get:project/taskcluster/json-e-deploy
+    # ..and notify on failure
+    - queue:route:notify.email.taskcluster-notifications@mozilla.com.*
+  to:
+    - roles:
+        - repo:github.com/json-e/json-e:branch:main
+
+- grant:
+    - assume:project:taskcluster:worker-test-scopes
+    - assume:worker-id:docker-worker/docker-worker
+    - assume:worker-id:random-local-worker/docker-worker
+    - docker-worker:cache:docker-worker-garbage-*
+    - docker-worker:capability:device:hostSharedMemory
+    - docker-worker:capability:device:hostSharedMemory:null-provisioner/*
+    - docker-worker:capability:device:loopbackAudio
+    - docker-worker:capability:device:loopbackAudio:null-provisioner/*
+    - docker-worker:capability:device:loopbackVideo
+    - docker-worker:capability:device:loopbackVideo:null-provisioner/*
+    - docker-worker:capability:disableSeccomp
+    - docker-worker:capability:disableSeccomp:null-provisioner/*
+    - docker-worker:capability:privileged
+    - docker-worker:capability:privileged:null-provisioner/*
+    - docker-worker:image:localhost:*
+    - purge-cache:null-provisioner/*
+    - queue:cancel-task
+    - queue:cancel-task-group:taskcluster-level-1/*
+    - queue:cancel-task:docker-worker-tests/*
+    - queue:claim-task
+    - queue:claim-task:null-provisioner/*
+    - queue:claim-work:null-provisioner/*
+    - queue:create-artifact:*
+    - queue:create-task:lowest:null-provisioner/*
+    - queue:create-task:lowest:proj-taskcluster/ci
+    - queue:get-artifact:private/docker-worker-tests/*
+    - queue:rerun-task:taskcluster-level-1/*
+    - queue:resolve-task
+    - queue:route:statuses
+    - queue:scheduler-id:docker-worker-tests
+    - queue:scheduler-id:taskcluster-github
+    - queue:seal-task-group:taskcluster-level-1/*
+    - queue:worker-id:docker-worker/docker-worker
+    - queue:worker-id:random-local-worker/docker-worker
+    - queue:worker-id:random-local-worker/dummy-worker-*
+    - secrets:get:project/taskcluster/taskcluster-worker/stateless-dns
+    - secrets:get:project/taskcluster/testing/docker-worker/ci-creds
+    - secrets:get:project/taskcluster/testing/docker-worker/pulse-creds
+  to:
+    - roles:
+        - repo:github.com/taskcluster/taskcluster:*
+        - project:taskcluster:docker-worker-tester
+
+- grant:
+    - auth:create-client:project/taskcluster/smoketest/*
+    - auth:create-role:project:taskcluster:smoketest:*
+    - auth:delete-client:project/taskcluster/smoketest/*
+    - auth:delete-role:project:taskcluster:smoketest:*
+    - auth:reset-access-token:project/taskcluster/smoketest/*
+    - auth:update-client:project/taskcluster/smoketest/*
+    - auth:update-role:project:taskcluster:smoketest:*
+    - project:taskcluster:smoketest:*
+    - purge-cache:built-in/succeed:smoketest-cache
+    - queue:create-task:highest:built-in/*
+    - queue:create-task:highest:built-in/fail
+    - queue:create-task:highest:built-in/succeed
+    - queue:route:index.project.taskcluster.smoketest.*
+    - queue:scheduler-id:smoketest
+    - secrets:get:project/taskcluster/smoketest/*
+    - secrets:set:project/taskcluster/smoketest/*
+  to:
+    - roles:
+        - project:taskcluster:smoketests
+
+- grant:
+    - assume:project:taskcluster:smoketests
+  to:
+    - roles:
+        - github-team:taskcluster/smoketesters
+
+- grant:
+    - assume:worker-id:test-worker-group/test-worker-id
+    - assume:worker-pool:test-provisioner/*
+    - assume:worker-type:test-provisioner/*
+    - auth:create-client:project/taskcluster:generic-worker-tester/TestReclaimCancelledTask
+    - auth:create-client:project/taskcluster:generic-worker-tester/TestResolveResolvedTask
+    - auth:sentry:generic-worker-tests
+    - docker-worker:cache:d2g-test
+    - docker-worker:capability:privileged:test-provisioner/test-*
+    - docker-worker:capability:device:hostSharedMemory:test-provisioner/test-*
+    - docker-worker:capability:device:kvm:test-provisioner/test-*
+    - docker-worker:capability:device:loopbackAudio
+    - docker-worker:capability:device:loopbackAudio:test-provisioner/test-*
+    - docker-worker:capability:device:loopbackVideo
+    - docker-worker:capability:device:loopbackVideo:test-provisioner/test-*
+    - docker-worker:feature:allowPtrace
+    - generic-worker:cache:apple-cache
+    - generic-worker:cache:banana-cache
+    - generic-worker:cache:devtools-app
+    - generic-worker:cache:test-modifications
+    - generic-worker:cache:unknown-issuer-app-cache
+    - generic-worker:os-group:test-provisioner/*
+    - generic-worker:run-as-administrator:test-provisioner/*
+    - generic-worker:run-task-as-current-user:test-provisioner/*
+    - generic-worker:loopback-audio:test-provisioner/test-*
+    - generic-worker:loopback-video:test-provisioner/test-*
+    - index:find-task:garbage.generic-worker-tests.*
+    - index:insert-task:garbage.generic-worker-tests.*
+    - queue:cancel-task:test-scheduler/*
+    - queue:create-artifact:public/*
+    - queue:create-task:highest:test-provisioner/*
+    - queue:get-artifact:SampleArtifacts/_/X.txt
+    - queue:get-artifact:SampleArtifacts/_/non-existent-artifact.txt
+    - queue:get-artifact:SampleArtifacts/b/c/d.jpg
+    - queue:resolve-task
+    - queue:scheduler-id:test-scheduler
+  to:
+    - roles:
+        - project:taskcluster:generic-worker-tester
+
+- grant:
+    - assume:project:taskcluster:generic-worker-tester
+    - queue:create-task:highest:proj-taskcluster/*
+    - generic-worker:cache:taskcluster-*
+    - generic-worker:run-task-as-current-user:proj-taskcluster/*
+    - generic-worker:os-group:proj-taskcluster/gw-ubuntu-24-04-gui/docker
+    - secrets:get:project/taskcluster/testing/generic-worker/ci-creds
+    - queue:scheduler-id:taskcluster-level-1
+    - queue:route:checks
+    - queue:route:index.taskcluster.cache.pr.docker-images.v2.*
+    - queue:route:index.taskcluster.cache.level-1.docker-images.v2.*
+  to:
+    - roles:
+        - repo:github.com/taskcluster/taskcluster:*
+        - repo:github.com/taskcluster/staging-releases:*
+
+- grant:
+    - queue:create-task:medium:proj-taskcluster/gw-ubuntu-24-04-gui
+  to:
+    - roles:
+        - repo:github.com/taskcluster/docker-exec-websocket-server:*
+        - repo:github.com/taskcluster/docker-exec-websocket-client:*

--- a/src/ciadmin/check/check_grants.py
+++ b/src/ciadmin/check/check_grants.py
@@ -65,11 +65,13 @@ async def check_grant_pools(generate_resources):
         "bitbar",
         "built-in",
         "lambda",
+        "null-provisioner",
         "performance-hardware",
         "proj-autophone",
         "releng-hardware",
         "scriptworker-k8s",
         "scriptworker-prov-v1",
+        "test-provisioner",
     }
 
     # We validate the raw grants rather than the generated grants to allow for

--- a/src/ciadmin/generate/worker_pools.py
+++ b/src/ciadmin/generate/worker_pools.py
@@ -280,7 +280,9 @@ def get_aws_provider_config(
                 {"availability-zone": availability_zone},
             )
 
-            for instance_type in sorted(instance_types):
+            for instance_type in sorted(
+                instance_types, key=lambda x: x["instanceType"]
+            ):
                 if is_invalid_aws_instance_type(
                     aws_config["invalid-instances"],
                     availability_zone,

--- a/worker-images.yml
+++ b/worker-images.yml
@@ -190,11 +190,11 @@ ronin_t_windows11_64_2009:
     deployment_id: "96de7f5"
     name: win11_64_2009
 
-# Fuzzing images migrated from community-tc.
-fuzzing-gw-ubuntu-24-04:
+# Images migrated from community-tc (shared across projects).
+gw-ubuntu-24-04:
   fxci-level1-gcp: projects/taskcluster-imaging/global/images/generic-worker-ubuntu-24-04-qioehfdraiiishpuvgvl
 
-fuzzing-gw-ubuntu-24-04-arm64:
+gw-ubuntu-24-04-arm64:
   fxci-level1-gcp: projects/taskcluster-imaging/global/images/generic-worker-ubuntu-24-04-arm64-mqscbutmsbawtytlroxk
 
 fuzzing-docker-worker-legacy:
@@ -204,11 +204,11 @@ fuzzing-docker-worker-legacy:
     us-west-1: ami-03e4f8db63254ce7e
     us-west-2: ami-0b5dd0bbb670ec80e
 
-fuzzing-gw-ubuntu-24-04-staging:
+gw-ubuntu-24-04-staging:
   aws:
     us-east-1: ami-02619e55246806e8d
 
-fuzzing-gw-win2022-gpu:
+gw-win2022-gpu:
   azure2:
     version: NA
     resource_group: rg-packer-worker-images
@@ -219,7 +219,7 @@ fuzzing-gw-win2022-gpu:
     south-central-us: imageset-wklenlbxaoeghdemjdyk-southcentralus
     west-us-2: imageset-cnnahgrkshgsftrapiac-westus2
 
-fuzzing-gw-win2022:
+gw-win2022:
   azure2:
     version: NA
     resource_group: rg-packer-worker-images

--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -3546,7 +3546,7 @@ pools:
           nss-corpus-update-worker: 5
       implementation: generic-worker/worker-runner-linux-multi
       regions: *default-gcp-regions
-      image: fuzzing-gw-ubuntu-24-04
+      image: gw-ubuntu-24-04
       instance_types:
         by-kind:
           grizzly-reduce-worker-android:
@@ -3566,7 +3566,7 @@ pools:
       maxCapacity: 20
       implementation: generic-worker/worker-runner-linux-multi
       regions: *default-gcp-regions
-      image: fuzzing-gw-ubuntu-24-04
+      image: gw-ubuntu-24-04
       instance_types:
         - *c3d-standard-4-60gb-lssd
 
@@ -3580,7 +3580,7 @@ pools:
       maxCapacity: 10
       implementation: generic-worker/worker-runner-linux-multi
       regions: [us-central1]
-      image: fuzzing-gw-ubuntu-24-04-arm64
+      image: gw-ubuntu-24-04-arm64
       instance_types:
         - disks:
             - *persistent-disk-60gb
@@ -3592,7 +3592,7 @@ pools:
     email_on_error: false
     provider_id: azure2
     config:
-      image: fuzzing-gw-win2022
+      image: gw-win2022
       implementation: generic-worker/windows-fuzzing
       worker-purpose: proj-fuzzing
       locations: [central-us, east-us]
@@ -3625,8 +3625,8 @@ pools:
     config:
       image:
         by-kind:
-          gpu: fuzzing-gw-win2022-gpu
-          ngpu: fuzzing-gw-win2022
+          gpu: gw-win2022-gpu
+          ngpu: gw-win2022
       implementation: generic-worker/windows-fuzzing
       worker-purpose: proj-fuzzing
       locations:
@@ -3681,7 +3681,7 @@ pools:
       maxCapacity: 5
       implementation: generic-worker/worker-runner-linux-multi
       regions: [us-east-1]
-      image: fuzzing-gw-ubuntu-24-04-staging
+      image: gw-ubuntu-24-04-staging
       security: untrusted
       instance_types:
         - instanceType: m5d.metal
@@ -3692,7 +3692,7 @@ pools:
     email_on_error: true
     provider_id: azure2
     config:
-      image: fuzzing-gw-win2022-gpu
+      image: gw-win2022-gpu
       implementation: generic-worker/windows-fuzzing
       worker-purpose: proj-fuzzing
       locations: [east-us, east-us-2, south-central-us, west-us-2]
@@ -3708,5 +3708,281 @@ pools:
           launchConfig:
             hardwareProfile:
               vmSize: Standard_NV12s_v3
+      worker-manager-config:
+        capacityPerInstance: 1
+
+  - pool_id: proj-taskcluster/ci
+    description: Taskcluster CI pool
+    owner: taskcluster-notifications+workers@mozilla.com
+    email_on_error: false
+    provider_id: fxci-level1-gcp
+    config:
+      minCapacity: 0
+      maxCapacity: 10
+      implementation: generic-worker/worker-runner-linux-multi
+      regions: *default-gcp-regions
+      image: gw-ubuntu-24-04
+      instance_types:
+        - *n2-standard-4-60gb-lssd
+      worker-config:
+        genericWorker:
+          config:
+            headlessTasks: true
+
+  - pool_id: proj-taskcluster/release
+    description: Trusted worker to build Taskcluster releases (only!)
+    owner: taskcluster-notifications+workers@mozilla.com
+    email_on_error: true
+    provider_id: fxci-level1-gcp
+    config:
+      minCapacity: 0
+      maxCapacity: 1
+      implementation: generic-worker/worker-runner-linux-multi
+      regions: *default-gcp-regions
+      image: gw-ubuntu-24-04
+      instance_types:
+        - *n2-standard-4-60gb-lssd
+      worker-config:
+        genericWorker:
+          config:
+            headlessTasks: true
+            idleTimeoutSecs: 300
+
+  # *-gui pools have headlessTasks: false for real GUI needed by GW CI tests.
+  - pool_id: proj-taskcluster/gw-ubuntu-24-04-gui
+    description: Taskcluster generic-worker Ubuntu 24.04 GUI pool
+    owner: taskcluster-notifications+workers@mozilla.com
+    email_on_error: true
+    provider_id: fxci-level1-gcp
+    config:
+      minCapacity: 0
+      maxCapacity: 20
+      implementation: generic-worker/worker-runner-linux-multi
+      regions: *default-gcp-regions
+      image: gw-ubuntu-24-04
+      instance_types:
+        - *n2-standard-4-60gb-lssd
+      worker-config:
+        genericWorker:
+          config:
+            headlessTasks: false
+            idleTimeoutSecs: 300
+
+  - pool_id: proj-taskcluster/gw-windows-2022-gui
+    description: Taskcluster generic-worker Windows 2022 GUI pool
+    owner: taskcluster-notifications+workers@mozilla.com
+    email_on_error: true
+    provider_id: azure2
+    config:
+      image: gw-win2022
+      implementation: generic-worker/windows-fuzzing
+      worker-purpose: proj-taskcluster
+      locations: [central-us, east-us]
+      maxCapacity: 10
+      armDeployment:
+        templateSpecId: /subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template/versions/1.0
+      worker-config:
+        genericWorker:
+          config:
+            headlessTasks: false
+            idleTimeoutSecs: 300
+      vmSizes:
+        - vmSize: Standard_F16s_v2
+          launchConfig:
+            hardwareProfile:
+              vmSize: Standard_F16s_v2
+      worker-manager-config:
+        capacityPerInstance: 1
+
+  - pool_id: proj-taskcluster/gw-ubuntu-24-04
+    description: Taskcluster generic-worker Ubuntu 24.04 pool
+    owner: taskcluster-notifications+workers@mozilla.com
+    email_on_error: true
+    provider_id: fxci-level1-gcp
+    config:
+      minCapacity: 0
+      maxCapacity: 50
+      implementation: generic-worker/worker-runner-linux-multi
+      regions: *default-gcp-regions
+      image: gw-ubuntu-24-04
+      instance_types:
+        - *n2-standard-4-60gb-lssd
+      worker-config:
+        genericWorker:
+          config:
+            headlessTasks: true
+            idleTimeoutSecs: 300
+
+  - pool_id: proj-taskcluster/gw-ubuntu-24-04-arm64
+    description: Taskcluster generic-worker Ubuntu 24.04 ARM64 pool
+    owner: taskcluster-notifications+workers@mozilla.com
+    email_on_error: true
+    provider_id: fxci-level1-gcp
+    config:
+      minCapacity: 0
+      maxCapacity: 5
+      implementation: generic-worker/worker-runner-linux-multi
+      regions: [us-central1]
+      image: gw-ubuntu-24-04-arm64
+      instance_types:
+        - disks:
+            - *persistent-disk-60gb
+          machine_type: t2a-standard-4
+      worker-config:
+        genericWorker:
+          config:
+            headlessTasks: true
+
+  - pool_id: proj-taskcluster/gw-ubuntu-staging-google
+    description: Taskcluster generic-worker Ubuntu 24.04 staging pool (GCP)
+    owner: taskcluster-notifications+workers@mozilla.com
+    email_on_error: true
+    provider_id: fxci-level1-gcp
+    config:
+      minCapacity: 0
+      maxCapacity: 1
+      implementation: generic-worker/worker-runner-linux-multi
+      regions: *default-gcp-regions
+      image: gw-ubuntu-24-04
+      instance_types:
+        - *n2-standard-4-60gb-lssd
+      worker-config:
+        genericWorker:
+          config:
+            headlessTasks: true
+            idleTimeoutSecs: 3600
+            shutdownMachineOnInternalError: false
+
+  - pool_id: proj-taskcluster/gw-windows-2022
+    description: Taskcluster generic-worker Windows 2022 pool
+    owner: taskcluster-notifications+workers@mozilla.com
+    email_on_error: true
+    provider_id: azure2
+    config:
+      image: gw-win2022
+      implementation: generic-worker/windows-fuzzing
+      worker-purpose: proj-taskcluster
+      locations: [central-us, east-us]
+      maxCapacity: 10
+      armDeployment:
+        templateSpecId: /subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template/versions/1.0
+      worker-config:
+        genericWorker:
+          config:
+            headlessTasks: true
+            idleTimeoutSecs: 300
+      vmSizes:
+        - vmSize: Standard_F16s_v2
+          launchConfig:
+            hardwareProfile:
+              vmSize: Standard_F16s_v2
+      worker-manager-config:
+        capacityPerInstance: 1
+
+  - pool_id: proj-taskcluster/gw-windows-2022-staging
+    description: Taskcluster generic-worker Windows 2022 staging pool
+    owner: taskcluster-notifications+workers@mozilla.com
+    email_on_error: true
+    provider_id: azure2
+    config:
+      image: gw-win2022
+      implementation: generic-worker/windows-fuzzing
+      worker-purpose: proj-taskcluster
+      locations: [central-us]
+      maxCapacity: 1
+      armDeployment:
+        templateSpecId: /subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template/versions/1.0
+      worker-config:
+        genericWorker:
+          config:
+            headlessTasks: true
+            idleTimeoutSecs: 3600
+            shutdownMachineOnInternalError: false
+      vmSizes:
+        - vmSize: Standard_F16s_v2
+          launchConfig:
+            hardwareProfile:
+              vmSize: Standard_F16s_v2
+      worker-manager-config:
+        capacityPerInstance: 1
+
+  - pool_id: proj-taskcluster/gw-windows-2022-gpu
+    description: Taskcluster generic-worker Windows 2022 GPU pool
+    owner: taskcluster-notifications+workers@mozilla.com
+    email_on_error: true
+    provider_id: azure2
+    config:
+      image: gw-win2022-gpu
+      implementation: generic-worker/windows-fuzzing
+      worker-purpose: proj-taskcluster
+      locations: [east-us, east-us-2, south-central-us, west-us-2]
+      maxCapacity: 3
+      armDeployment:
+        templateSpecId: /subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template/versions/1.0
+      worker-config:
+        genericWorker:
+          config:
+            headlessTasks: false
+      vmSizes:
+        - vmSize: Standard_NV12s_v3
+          launchConfig:
+            hardwareProfile:
+              vmSize: Standard_NV12s_v3
+      worker-manager-config:
+        capacityPerInstance: 1
+
+  - pool_id: proj-taskcluster/gw-windows-2022-gpu-staging
+    description: Taskcluster generic-worker Windows 2022 GPU staging pool
+    owner: taskcluster-notifications+workers@mozilla.com
+    email_on_error: true
+    provider_id: azure2
+    config:
+      image: gw-win2022-gpu
+      implementation: generic-worker/windows-fuzzing
+      worker-purpose: proj-taskcluster
+      locations: [west-us-2]
+      maxCapacity: 1
+      armDeployment:
+        templateSpecId: /subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template/versions/1.0
+      worker-config:
+        genericWorker:
+          config:
+            headlessTasks: false
+            idleTimeoutSecs: 3600
+            shutdownMachineOnInternalError: false
+            runAfterUserCreation: C:\Windows\System32\calc.exe
+      vmSizes:
+        - vmSize: Standard_NV12s_v3
+          launchConfig:
+            hardwareProfile:
+              vmSize: Standard_NV12s_v3
+      worker-manager-config:
+        capacityPerInstance: 1
+
+  - pool_id: proj-taskcluster/gw-windows-11-24h2-staging
+    description: Taskcluster generic-worker Windows 11 24H2 staging pool
+    owner: taskcluster-notifications+workers@mozilla.com
+    email_on_error: true
+    provider_id: azure2
+    config:
+      image: gw-win2022
+      implementation: generic-worker/windows-fuzzing
+      worker-purpose: proj-taskcluster
+      locations: [central-us, east-us]
+      maxCapacity: 1
+      armDeployment:
+        templateSpecId: /subscriptions/108d46d5-fe9b-4850-9a7d-8c914aa6c1f0/resourceGroups/template-spec/providers/Microsoft.Resources/templateSpecs/taskcluster-arm-template/versions/1.0
+      worker-config:
+        genericWorker:
+          config:
+            headlessTasks: false
+            idleTimeoutSecs: 3600
+            shutdownMachineOnInternalError: false
+            runAfterUserCreation: C:\Windows\System32\calc.exe
+      vmSizes:
+        - vmSize: Standard_F8s_v2
+          launchConfig:
+            hardwareProfile:
+              vmSize: Standard_F8s_v2
       worker-manager-config:
         capacityPerInstance: 1


### PR DESCRIPTION
Migrate proj-taskcluster entities from https://community-tc.services.mozilla.com/ to https://firefox-ci-tc.services.mozilla.com/.