### PR TITLE
fix(workflows): only serialize the `apply` job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,14 +17,6 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: read
 
-# Serialize every deploy into a single group so only one ever runs at a time.
-# A trigger arriving mid-deploy queues one pending run rather than starting a
-# concurrent apply. cancel-in-progress is false so an in-flight apply is never
-# interrupted.
-concurrency:
-  group: deploy
-  cancel-in-progress: false
-
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -58,6 +50,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: check
     environment: apply-${{matrix.environment}}
+    # Serialize only the actual deploy into a single group so only one apply
+    # ever runs at a time. A trigger arriving mid-deploy queues one pending
+    # run rather than starting a concurrent apply. cancel-in-progress is
+    # false so an in-flight apply is never interrupted. Checks (including on
+    # PRs) are unaffected and always run immediately.
+    concurrency:
+      group: deploy-apply-${{ matrix.environment }}
+      cancel-in-progress: false
     strategy:
       matrix:
         environment: ["firefoxci"]


### PR DESCRIPTION
Checks can and should run in parallel, otherwise they end up getting canceled on some PRs.