### PR TITLE
bug 2051769: enable lando for try-comm-central

### DIFF
--- a/grants.d/grants.yml
+++ b/grants.d/grants.yml
@@ -2343,6 +2343,13 @@
 
 - grant:
     - project:releng:lando:action:*
+    - project:releng:lando:repo:{lando_repo}
+  to:
+    - project:
+        alias: try-comm-central
+
+- grant:
+    - project:releng:lando:action:*
     # there are staging versions of all production repos; allow access
     # to all of them
     - project:releng:lando:repo:staging-firefox-*

--- a/projects.yml
+++ b/projects.yml
@@ -485,6 +485,7 @@ try:
     trust-domain-scopes: true
 try-comm-central:
   repo: https://hg.mozilla.org/try-comm-central
+  lando_repo: thunderbird-infra-testing-main
   repo_type: hg
   access: scm_level_1
   branches:
@@ -496,6 +497,7 @@ try-comm-central:
     gecko-actions: true
     gecko-roles: true
     hg-push: true
+    lando: true
     taskgraph-cron: false
     treeherder-reporting: true
     trust-domain-scopes: true


### PR DESCRIPTION
This will give folks a place to mess around with dev workers if/when needed.

cc @dandarnell 