### PR TITLE
fix: tighten up staging landoscript scopes for firefox

### DIFF
--- a/grants.d/grants.yml
+++ b/grants.d/grants.yml
@@ -2332,16 +2332,21 @@
         - mozillians-group:windows-laf-token-managers
 
 ### landoscript scopes
-# on try, we're fairly liberal with these scopes for ease of testing, and
-# allow all actions to be run through any means.
+# on try and in PRs, we're fairly liberal with these scopes for ease of testing,
+# and allow all actions to be run through any means.
 - grant:
     - project:releng:lando:action:*
-    # there are staging versions of all production repos; allow try access
-    # to all of them
-    - project:releng:lando:repo:staging-*
+    - project:releng:lando:repo:{lando_repo}
   to:
     - project:
         alias: try
+
+- grant:
+    - project:releng:lando:action:*
+    # there are staging versions of all production repos; allow access
+    # to all of them
+    - project:releng:lando:repo:staging-firefox-*
+  to:
     - project:
         alias: firefox
         job: [pull-request:trusted]

--- a/projects.yml
+++ b/projects.yml
@@ -462,7 +462,10 @@ cypress:
       - nightly-desktop-win64-aarch64
 try:
   repo: https://hg.mozilla.org/try
-  lando_repo: ff-test-dev
+  # This is used as a substitution in grants; the try repo is allowed to
+  # use grants for all staging repositories (to allow for testing against
+  # the staging beta, release, etc. repositories).
+  lando_repo: staging-firefox-*
   repo_type: hg
   access: scm_level_1
   branches:


### PR DESCRIPTION
We're going to be adding similar scopes for Thunderbird, and don't want to cross the streams between the staging Thunderbird and Firefox repositories.