### PR TITLE
Bug 2053463 - Create dedicated worker pools for updatebot

### DIFF
--- a/worker-pools.yml
+++ b/worker-pools.yml
@@ -436,6 +436,17 @@ pools:
         chain-of-trust: trusted
         suffix: ''
         instance_types: [*c3d-standard-16-lssd]
+      # Updatebot runs on-task LLMs so isolate to mitigate prompt injections
+      - pool-group: gecko-1
+        suffix: 'updatebot'
+        instance_types: [*c3d-standard-16-lssd]
+      - pool-group: gecko-2
+        suffix: 'updatebot'
+        instance_types: [*c3d-standard-16-lssd]
+      - pool-group: gecko-3
+        chain-of-trust: trusted
+        suffix: 'updatebot'
+        instance_types: [*c3d-standard-16-lssd]
       - pool-group: comm-1
         suffix: ''
         instance_types: [*c3d-standard-16-lssd]
@@ -524,7 +535,10 @@ pools:
       minCapacity: 0
       maxCapacity:
         by-pool-group:
-          gecko-.*: 1000
+          gecko-.*:
+            by-suffix:
+              updatebot: 5
+              default: 1000
           comm-.*: 300
           app-services-1: 50
           app-services-3: 100
@@ -2121,6 +2135,14 @@ pools:
       - pool-group: gecko-3
         chain-of-trust: trusted
         suffix: headless
+      # Updatebot runs on-task LLMs so isolate to mitigate prompt injection
+      - pool-group: gecko-1
+        suffix: updatebot
+      - pool-group: gecko-2
+        suffix: updatebot
+      - pool-group: gecko-3
+        suffix: updatebot
+        chain-of-trust: trusted
       - pool-group: comm-1
       - pool-group: comm-3
         chain-of-trust: trusted


### PR DESCRIPTION
Updatebot will soon start using on task LLMs which makes it susceptible to prompt injection. Isolated pools ensures the blast radius is very small if it happens.