### PR TITLE
fix: switch translations to public_restricted pull request policy

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -1491,7 +1491,7 @@ translations:
   features:
     github-taskgraph: true
     github-pull-request:
-      policy: public
+      policy: public_restricted
     taskgraph-actions: true
     taskgraph-cron: true
     trust-domain-scopes: true
@@ -1518,7 +1518,7 @@ staging-firefox-translations-training:
   features:
     github-taskgraph: true
     github-pull-request:
-      policy: public
+      policy: public_restricted
     taskgraph-actions: true
     taskgraph-cron: true
     trust-domain-scopes: true


### PR DESCRIPTION
https://github.com/mozilla/translations/issues/1444 has highlighted that this project relies on scopes granted only to trusted pull requests after https://github.com/mozilla-releng/fxci-config/pull/1014 was merged.

The current pull request policy doesn't allow for this; moving to `public_restricted` allows us to maintain a safe set of scopes for untrusted PRs, while granting secrets to those opened by collaborators.